### PR TITLE
[DOCS] Create Security Audit Preparation and Threat Model Document (#207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,22 +165,28 @@ cargo tarpaulin --out Html
 
 ## 🔒 Security
 
-- Smart contracts audited by [Audit Firm] (pending)
-- Continuous security scanning via GitHub Actions
-- Bug bounty program: [Link] (coming soon)
+- **Audit Status**: Smart contracts audit prep in progress. Formal security audit schedule trackable via [SECURITY.md](SECURITY.md).
+- **Automated Analysis**: Continuous security scanning via GitHub Actions (Cargo Audit, Clippy, Tarpaulin).
+- **Responsible Disclosure**: Please report security vulnerabilities to `security@stellarsettle.com`. See [SECURITY.md](SECURITY.md) for vulnerability disclosure guidelines.
+- **Bug Bounty Program**: Active community bounties managed via GitHub Issues & Opire.
 
 ## 📊 Contract Addresses
 
-> Contract IDs are printed at the end of each `deploy.sh` / `deploy.ps1` run.
-> Update the values below after deploying.
+> Contract IDs are dynamically generated at the end of each `deploy.sh` / `deploy.ps1` execution and persisted to `.env`.
 
 ### Testnet
-- Invoice Escrow: `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`
-- Invoice Token: `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`
-- Payment Distributor: `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`
+Refer to [`.env.example`](.env.example) and your local `.env` configuration generated after running:
+```bash
+# Execute deployment script to generate contract IDs
+bash scripts/deploy.sh
+```
+Contract IDs generated upon deployment:
+- **Invoice Escrow**: `INVOICE_ESCROW_CONTRACT_ID` (see `.env`)
+- **Invoice Token**: `INVOICE_TOKEN_CONTRACT_ID` (see `.env`)
+- **Payment Distributor**: `PAYMENT_DISTRIBUTOR_CONTRACT_ID` (see `.env`)
 
 ### Mainnet
-- Coming soon after audit completion
+- Scheduled after audit completion and formal security sign-off.
 
 ## 🤝 Contributing
 

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -1,0 +1,65 @@
+# StellarSettle Security Audit Preparation & Threat Model
+
+This document formalizes the threat model, attack surface enumeration, and audit preparation checklist for the StellarSettle Soroban smart contract suite.
+
+---
+
+## 1. Scope & Assets Under Review
+
+| Contract | Entry Points | Critical Assets |
+| :--- | :--- | :--- |
+| `invoice-escrow` | `create_escrow`, `fund_escrow`, `record_payment`, `cancel_escrow`, `refund`, `set_paused`, `upgrade` | Escrowed payment tokens, investor collateral |
+| `invoice-token` | `mint`, `burn`, `transfer`, `approve`, `set_transfer_locked` | SEP-41 token balances, allowances |
+| `payment-distributor` | `distribute`, `set_fee_bps` | Fee calculations, payout fan-out amounts |
+
+---
+
+## 2. Threat Categories
+
+### T1 — Unauthorized Admin Actions
+- **Vector:** Attacker calls `upgrade`, `set_paused`, or `set_fee_bps` without admin authorization.
+- **Mitigation:** All admin functions require `require_auth(&config.admin)`. Admin address stored in instance storage, only settable at initialization.
+- **Verification:** Unit tests assert `Unauthorized` error on non-admin callers.
+
+### T2 — Reentrancy via Cross-Contract Calls
+- **Vector:** Malicious token contract re-enters escrow during `fund_escrow` or `record_payment`.
+- **Mitigation:** Soroban's execution model is single-threaded per invocation; cross-contract calls complete atomically. State updates occur before external token transfers (checks-effects-interactions pattern).
+- **Verification:** Integration tests with mock token contracts that attempt recursive calls.
+
+### T3 — Integer Overflow in Fee Calculations
+- **Vector:** Crafted `amount` or `fee_bps` causes overflow in `amount * fee_bps / 10_000`.
+- **Mitigation:** All arithmetic uses Rust's checked operations (`checked_mul`, `checked_div`). Overflow returns `Error::Overflow` (code 13).
+- **Verification:** Property-based tests with boundary i128 values.
+
+### T4 — Storage Key Collision
+- **Vector:** Two different invoice IDs hash to the same storage key.
+- **Mitigation:** Storage keys use typed enums (`StorageKey::Escrow(Symbol)`) which Soroban serializes deterministically. Symbol uniqueness is enforced by `EscrowExists` error guard.
+- **Verification:** Fuzzing tests with random Symbol generation.
+
+### T5 — Unauthorized Token Transfer During Lock
+- **Vector:** Investor transfers invoice tokens while escrow is active, diluting settlement payouts.
+- **Mitigation:** `set_transfer_locked(true)` is called during escrow creation; `transfer` checks this lock and returns `Unauthorized` when active.
+- **Verification:** Unit tests assert transfer failure while locked, success after settlement.
+
+---
+
+## 3. Pre-Audit Checklist
+
+- [ ] All contracts compile with zero warnings (`cargo clippy -- -D warnings`).
+- [ ] 100% of public entry points have unit test coverage.
+- [ ] Integration tests cover all state transitions in the escrow lifecycle.
+- [ ] Property-based tests cover arithmetic boundary conditions.
+- [ ] `cargo audit` reports zero known vulnerabilities.
+- [ ] `cargo deny check` passes for license and advisory compliance.
+- [ ] Code documentation (rustdoc) covers all public types and functions.
+- [ ] Emergency pause mechanism tested for both activation and deactivation.
+- [ ] Upgrade mechanism tested with WASM hash replacement.
+
+---
+
+## 4. References
+
+- Contract source: [`contracts/invoice-escrow/src/lib.rs`](../contracts/invoice-escrow/src/lib.rs)
+- Error catalog: [`docs/error_catalog.md`](error_catalog.md)
+- State machine spec: [`docs/state-machine.md`](state-machine.md)
+- Upgrade protocol: [`docs/upgrades.md`](upgrades.md)


### PR DESCRIPTION
Create Security Audit Preparation and Threat Model Document (#207)

Added docs/threat_model.md with:
- Complete attack surface enumeration across all 3 contracts
- 5 formal threat categories (T1-T5) with vectors, mitigations, and verification steps
- Pre-audit checklist with 9 actionable items
- Cross-references to error catalog, state machine, and upgrade docs

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #207