### PR TITLE
Fix issues 78, 86, 89 (invoice-escrow)

### DIFF
--- a/contracts/invoice-escrow/src/errors.rs
+++ b/contracts/invoice-escrow/src/errors.rs
@@ -40,4 +40,6 @@ pub enum Error {
     InvalidPayer = 16,
     /// Due date is invalid (e.g., in the past or zero).
     InvalidDueDate = 17,
+    /// Caller is not on the buyer whitelist and cannot fund escrows.
+    NotWhitelisted = 18,
 }

--- a/contracts/invoice-escrow/src/events.rs
+++ b/contracts/invoice-escrow/src/events.rs
@@ -2,6 +2,19 @@
 
 use soroban_sdk::{Address, Env, Symbol};
 
+use crate::types::EscrowStatus;
+
+/// Publish a lifecycle transition event carrying the new status and ledger
+/// timestamp, in addition to the narrower per-action events below. Lets
+/// off-chain indexers reconstruct full escrow lifecycle history/metadata
+/// from a single event stream instead of correlating five separate events.
+pub fn escrow_status_changed(env: &Env, inv_id: Symbol, status: EscrowStatus, timestamp: u64) {
+    env.events().publish(
+        (Symbol::new(env, "escrow_status_changed"),),
+        (inv_id, status as u32, timestamp),
+    );
+}
+
 /// Publish escrow_created event.
 pub fn escrow_created(
     env: &Env,

--- a/contracts/invoice-escrow/src/lib.rs
+++ b/contracts/invoice-escrow/src/lib.rs
@@ -48,9 +48,43 @@ impl InvoiceEscrow {
             fee_bps: platform_fee_bps,
             payment_distributor: None,
             paused: false,
+            whitelist_enabled: false,
         };
         storage::set_config(&env, &config);
         Ok(())
+    }
+
+    /// Admin-only: enable/disable buyer whitelist enforcement on `fund_escrow`.
+    pub fn set_whitelist_enabled(env: Env, admin: Address, enabled: bool) -> Result<(), Error> {
+        admin.require_auth();
+        let mut config = storage::get_config(&env).ok_or(Error::NotInit)?;
+        if config.admin != admin {
+            return Err(Error::Unauthorized);
+        }
+        config.whitelist_enabled = enabled;
+        storage::set_config(&env, &config);
+        Ok(())
+    }
+
+    /// Admin-only: add or remove a buyer from the whitelist.
+    pub fn set_buyer_whitelisted(
+        env: Env,
+        admin: Address,
+        buyer: Address,
+        allowed: bool,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let config = storage::get_config(&env).ok_or(Error::NotInit)?;
+        if config.admin != admin {
+            return Err(Error::Unauthorized);
+        }
+        storage::set_whitelisted(&env, &buyer, allowed);
+        Ok(())
+    }
+
+    /// View: is `buyer` whitelisted to fund escrows.
+    pub fn is_buyer_whitelisted(env: Env, buyer: Address) -> bool {
+        storage::is_whitelisted(&env, &buyer)
     }
 
     /// Create an escrow for an invoice. Caller (seller) must be authenticated.
@@ -103,7 +137,7 @@ impl InvoiceEscrow {
         storage::set_escrow(&env, invoice_id.clone(), &data);
         events::escrow_created(
             &env,
-            invoice_id,
+            invoice_id.clone(),
             &seller,
             &debtor,
             face_value,
@@ -112,6 +146,12 @@ impl InvoiceEscrow {
             &payment_token,
             &invoice_token,
             &commitment,
+        );
+        events::escrow_status_changed(
+            &env,
+            invoice_id,
+            EscrowStatus::Created,
+            current_timestamp,
         );
         Ok(())
     }
@@ -133,7 +173,13 @@ impl InvoiceEscrow {
         }
         data.status = EscrowStatus::Cancelled;
         storage::set_escrow(&env, invoice_id.clone(), &data);
-        events::escrow_cancelled(&env, invoice_id, &seller);
+        events::escrow_cancelled(&env, invoice_id.clone(), &seller);
+        events::escrow_status_changed(
+            &env,
+            invoice_id,
+            EscrowStatus::Cancelled,
+            env.ledger().timestamp(),
+        );
         Ok(())
     }
 
@@ -152,6 +198,9 @@ impl InvoiceEscrow {
         }
         let config = storage::get_config(&env).ok_or(Error::NotInit)?;
         ensure_not_paused(&config)?;
+        if config.whitelist_enabled && !storage::is_whitelisted(&env, &buyer) {
+            return Err(Error::NotWhitelisted);
+        }
 
         let mut data =
             storage::get_escrow(&env, invoice_id.clone()).ok_or(Error::EscrowNotFound)?;
@@ -206,12 +255,20 @@ impl InvoiceEscrow {
         storage::set_escrow(&env, invoice_id.clone(), &data);
         events::escrow_funded(
             &env,
-            invoice_id,
+            invoice_id.clone(),
             &buyer,
             amount,
             data.funded_amt,
             data.purchase_price,
         );
+        if data.status == EscrowStatus::Funded {
+            events::escrow_status_changed(
+                &env,
+                invoice_id,
+                EscrowStatus::Funded,
+                env.ledger().timestamp(),
+            );
+        }
         Ok(())
     }
 
@@ -340,7 +397,15 @@ impl InvoiceEscrow {
             );
         }
 
-        events::payment_settled(&env, invoice_id, amount, platform_fee, investor_amount);
+        events::payment_settled(&env, invoice_id.clone(), amount, platform_fee, investor_amount);
+        if data.status == EscrowStatus::Settled {
+            events::escrow_status_changed(
+                &env,
+                invoice_id,
+                EscrowStatus::Settled,
+                env.ledger().timestamp(),
+            );
+        }
         Ok(())
     }
 
@@ -426,7 +491,13 @@ impl InvoiceEscrow {
             soroban_sdk::vec![&env, contract.to_val(), false.into_val(&env)],
         );
 
-        events::escrow_refunded(&env, invoice_id, amount_to_refund);
+        events::escrow_refunded(&env, invoice_id.clone(), amount_to_refund);
+        events::escrow_status_changed(
+            &env,
+            invoice_id,
+            EscrowStatus::Refunded,
+            env.ledger().timestamp(),
+        );
         Ok(())
     }
 

--- a/contracts/invoice-escrow/src/storage.rs
+++ b/contracts/invoice-escrow/src/storage.rs
@@ -1,8 +1,24 @@
 //! Storage helpers: instance for config, persistent for escrow data.
 
-use soroban_sdk::Symbol;
+use soroban_sdk::{Address, Symbol};
 
 use crate::types::{Config, EscrowData, StorageKey};
+
+/// Ledgers below which a persistent entry's TTL is extended (~7 days at 5s/ledger).
+const TTL_THRESHOLD: u32 = 120_960;
+/// Ledgers to extend a persistent entry's TTL to when bumped (~30 days at 5s/ledger).
+const TTL_EXTEND_TO: u32 = 518_400;
+
+/// Extend the TTL of an escrow's persistent storage entry so it survives
+/// ledger pruning across the full lifetime of a (potentially long-lived,
+/// e.g. multi-month) invoice, not just the archival minimum.
+pub fn extend_ttl(env: &soroban_sdk::Env, inv_id: Symbol) {
+    env.storage().persistent().extend_ttl(
+        &StorageKey::Escrow(inv_id),
+        TTL_THRESHOLD,
+        TTL_EXTEND_TO,
+    );
+}
 
 /// Load contract config from instance storage.
 pub fn get_config(env: &soroban_sdk::Env) -> Option<Config> {
@@ -15,15 +31,25 @@ pub fn set_config(env: &soroban_sdk::Env, config: &Config) {
 }
 
 /// Load escrow data for an invoice from persistent storage.
+/// Extends the entry's TTL on every access so actively-used escrows never
+/// expire mid-lifecycle regardless of how long between state transitions.
 pub fn get_escrow(env: &soroban_sdk::Env, inv_id: Symbol) -> Option<EscrowData> {
-    env.storage().persistent().get(&StorageKey::Escrow(inv_id))
+    let data = env
+        .storage()
+        .persistent()
+        .get(&StorageKey::Escrow(inv_id.clone()));
+    if data.is_some() {
+        extend_ttl(env, inv_id);
+    }
+    data
 }
 
-/// Save escrow data for an invoice to persistent storage.
+/// Save escrow data for an invoice to persistent storage, extending its TTL.
 pub fn set_escrow(env: &soroban_sdk::Env, inv_id: Symbol, data: &EscrowData) {
     env.storage()
         .persistent()
-        .set(&StorageKey::Escrow(inv_id), data);
+        .set(&StorageKey::Escrow(inv_id.clone()), data);
+    extend_ttl(env, inv_id);
 }
 
 /// Check if an escrow exists for the given invoice.
@@ -58,5 +84,26 @@ pub fn set_funder_amount(
         env.storage()
             .persistent()
             .set(&StorageKey::FunderAmount(inv_id, funder.clone()), &amount);
+    }
+}
+
+/// Whether `buyer` is whitelisted to fund (buy) escrows. Absent entry = not whitelisted.
+pub fn is_whitelisted(env: &soroban_sdk::Env, buyer: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::BuyerWhitelist(buyer.clone()))
+        .unwrap_or(false)
+}
+
+/// Set (or clear) a buyer's whitelist status.
+pub fn set_whitelisted(env: &soroban_sdk::Env, buyer: &Address, allowed: bool) {
+    if allowed {
+        env.storage()
+            .persistent()
+            .set(&StorageKey::BuyerWhitelist(buyer.clone()), &true);
+    } else {
+        env.storage()
+            .persistent()
+            .remove(&StorageKey::BuyerWhitelist(buyer.clone()));
     }
 }

--- a/contracts/invoice-escrow/src/types.rs
+++ b/contracts/invoice-escrow/src/types.rs
@@ -13,6 +13,8 @@ pub enum StorageKey {
     Escrow(soroban_sdk::Symbol),
     /// Persistent: funder amounts by (invoice_id, funder_address).
     FunderAmount(soroban_sdk::Symbol, soroban_sdk::Address),
+    /// Persistent: whether a given address is whitelisted to fund (buy) escrows.
+    BuyerWhitelist(soroban_sdk::Address),
 }
 
 /// Global contract configuration.
@@ -27,6 +29,10 @@ pub struct Config {
     pub payment_distributor: Option<soroban_sdk::Address>,
     /// Emergency pause flag for lifecycle-changing operations.
     pub paused: bool,
+    /// When true, `fund_escrow` requires the buyer to be on the whitelist.
+    /// Defaults to false (opt-in) so existing deployments/tests are unaffected
+    /// until an admin explicitly enables it.
+    pub whitelist_enabled: bool,
 }
 
 /// Lifecycle status of an escrow.


### PR DESCRIPTION
Closes #78, Closes #86, Closes #89

- **#78**: `storage::get_escrow`/`set_escrow` now call `extend_ttl` on every access, bumping the persistent TTL (threshold ~7d, extend-to ~30d) so an escrow's storage entry survives ledger pruning across its full lifecycle instead of only the archival minimum.
- **#86**: added `events::escrow_status_changed(inv_id, status, timestamp)`, emitted at all 5 lifecycle transitions (Created, Funded, Settled, Refunded, Cancelled) alongside the existing narrower per-action events — lets an indexer reconstruct full lifecycle history from one event stream.
- **#89**: added buyer whitelist enforcement on `fund_escrow`, gated by a new `Config.whitelist_enabled` flag (defaults `false` on `initialize`, so existing deployments/tests are unaffected until an admin opts in via the new `set_whitelist_enabled`). Admin-only `set_buyer_whitelisted`/`is_buyer_whitelisted` manage the whitelist itself. New `Error::NotWhitelisted`.

## Test plan
- [x] `cargo build -p invoice-escrow` — clean
- Note: `cargo test -p invoice-escrow` currently fails to compile on `dev` as well (pre-existing, unrelated to this PR) — `soroban-env-host`'s testutils pulls in an `ed25519-dalek`/`rand_core` version combination where `ChaCha20Rng` doesn't satisfy `CryptoRng`. Confirmed via `git stash` that this reproduces identically on a clean `dev` checkout.