### PR TITLE
Invoice token and escrow enhancements: metadata compliance, allowance extension, signed funding, storage cleanup

### DIFF
--- a/contracts/invoice-escrow/src/errors.rs
+++ b/contracts/invoice-escrow/src/errors.rs
@@ -40,6 +40,8 @@ pub enum Error {
     InvalidPayer = 16,
     /// Due date is invalid (e.g., in the past or zero).
     InvalidDueDate = 17,
+    /// Nonce has already been consumed by a prior signed off-chain approval (replay attempt).
+    NonceAlreadyUsed = 18,
     /// Escrow is not yet in a terminal state (Settled, Refunded, or Cancelled) and cannot be cleaned up.
     EscrowNotSettled = 19,
 }

--- a/contracts/invoice-escrow/src/errors.rs
+++ b/contracts/invoice-escrow/src/errors.rs
@@ -40,4 +40,6 @@ pub enum Error {
     InvalidPayer = 16,
     /// Due date is invalid (e.g., in the past or zero).
     InvalidDueDate = 17,
+    /// Escrow is not yet in a terminal state (Settled, Refunded, or Cancelled) and cannot be cleaned up.
+    EscrowNotSettled = 19,
 }

--- a/contracts/invoice-escrow/src/events.rs
+++ b/contracts/invoice-escrow/src/events.rs
@@ -72,6 +72,12 @@ pub fn escrow_cancelled(env: &Env, inv_id: Symbol, seller: &Address) {
         .publish((Symbol::new(env, "escrow_cancelled"),), (inv_id, seller));
 }
 
+/// Publish escrow_cleaned_up event once a terminal escrow's storage has been reclaimed.
+pub fn escrow_cleaned_up(env: &Env, inv_id: Symbol) {
+    env.events()
+        .publish((Symbol::new(env, "escrow_cleaned"),), inv_id);
+}
+
 /// Publish platform fee update event with old and new basis points.
 pub fn platform_fee_updated(env: &Env, old_fee_bps: u32, new_fee_bps: u32) {
     env.events().publish(

--- a/contracts/invoice-escrow/src/events.rs
+++ b/contracts/invoice-escrow/src/events.rs
@@ -72,6 +72,20 @@ pub fn escrow_cancelled(env: &Env, inv_id: Symbol, seller: &Address) {
         .publish((Symbol::new(env, "escrow_cancelled"),), (inv_id, seller));
 }
 
+/// Publish escrow_funded event for a signed off-chain approval, including the consumed nonce.
+pub fn escrow_funded_signed(
+    env: &Env,
+    inv_id: Symbol,
+    buyer: &Address,
+    amount: i128,
+    nonce: u64,
+) {
+    env.events().publish(
+        (Symbol::new(env, "escrow_fund_sig"),),
+        (inv_id, buyer, amount, nonce),
+    );
+}
+
 /// Publish escrow_cleaned_up event once a terminal escrow's storage has been reclaimed.
 pub fn escrow_cleaned_up(env: &Env, inv_id: Symbol) {
     env.events()

--- a/contracts/invoice-escrow/src/lib.rs
+++ b/contracts/invoice-escrow/src/lib.rs
@@ -146,15 +146,50 @@ impl InvoiceEscrow {
         amount: i128,
     ) -> Result<(), Error> {
         buyer.require_auth();
+        Self::fund_escrow_core(&env, invoice_id, &buyer, amount)
+    }
+
+    /// Fund the escrow on behalf of `buyer` using a signed off-chain approval that a relayer
+    /// submits on their behalf. `buyer` authorizes exactly this `(invoice_id, amount, nonce)`
+    /// tuple, and `nonce` must be strictly greater than the last nonce consumed by `buyer` so
+    /// the same signed approval cannot be replayed.
+    pub fn fund_escrow_signed(
+        env: Env,
+        invoice_id: Symbol,
+        buyer: Address,
+        amount: i128,
+        nonce: u64,
+    ) -> Result<(), Error> {
+        buyer.require_auth_for_args((invoice_id.clone(), amount, nonce).into_val(&env));
+
+        let last_nonce = storage::get_nonce(&env, &buyer);
+        if nonce <= last_nonce {
+            return Err(Error::NonceAlreadyUsed);
+        }
+
+        Self::fund_escrow_core(&env, invoice_id.clone(), &buyer, amount)?;
+
+        storage::set_nonce(&env, &buyer, nonce);
+        events::escrow_funded_signed(&env, invoice_id, &buyer, amount, nonce);
+        Ok(())
+    }
+
+    /// Shared funding logic used by both the directly-authorized and signed-approval entry points.
+    fn fund_escrow_core(
+        env: &Env,
+        invoice_id: Symbol,
+        buyer: &Address,
+        amount: i128,
+    ) -> Result<(), Error> {
         // Fail fast: validate amount before hitting storage.
         if amount <= 0 {
             return Err(Error::InvalidAmount);
         }
-        let config = storage::get_config(&env).ok_or(Error::NotInit)?;
+        let config = storage::get_config(env).ok_or(Error::NotInit)?;
         ensure_not_paused(&config)?;
 
         let mut data =
-            storage::get_escrow(&env, invoice_id.clone()).ok_or(Error::EscrowNotFound)?;
+            storage::get_escrow(env, invoice_id.clone()).ok_or(Error::EscrowNotFound)?;
         if data.status == EscrowStatus::Cancelled {
             return Err(Error::EscrowCancelled);
         }
@@ -168,28 +203,28 @@ impl InvoiceEscrow {
             return Err(Error::InvalidAmount);
         }
 
-        let token = token::Client::new(&env, &data.token);
+        let token = token::Client::new(env, &data.token);
         let contract = env.current_contract_address();
-        token.transfer(&buyer, &contract, &amount);
+        token.transfer(buyer, &contract, &amount);
 
         // Mint invoice tokens to the buyer to represent their ownership share
         env.invoke_contract::<()>(
             &data.inv_token,
-            &Symbol::new(&env, "mint"),
+            &Symbol::new(env, "mint"),
             soroban_sdk::vec![
-                &env,
+                env,
                 buyer.to_val(),
-                amount.into_val(&env),
+                amount.into_val(env),
                 contract.to_val()
             ],
         );
 
         // Track this funder's contribution
-        let current_funder_amt = storage::get_funder_amount(&env, invoice_id.clone(), &buyer);
+        let current_funder_amt = storage::get_funder_amount(env, invoice_id.clone(), buyer);
         let new_funder_amt = current_funder_amt
             .checked_add(amount)
             .ok_or(Error::Overflow)?;
-        storage::set_funder_amount(&env, invoice_id.clone(), &buyer, new_funder_amt);
+        storage::set_funder_amount(env, invoice_id.clone(), buyer, new_funder_amt);
 
         data.funded_amt = new_funded;
 
@@ -203,11 +238,11 @@ impl InvoiceEscrow {
             data.status = EscrowStatus::Funded;
         }
 
-        storage::set_escrow(&env, invoice_id.clone(), &data);
+        storage::set_escrow(env, invoice_id.clone(), &data);
         events::escrow_funded(
-            &env,
+            env,
             invoice_id,
-            &buyer,
+            buyer,
             amount,
             data.funded_amt,
             data.purchase_price,

--- a/contracts/invoice-escrow/src/lib.rs
+++ b/contracts/invoice-escrow/src/lib.rs
@@ -490,6 +490,29 @@ impl InvoiceEscrow {
         let config = storage::get_config(&env).ok_or(Error::NotInit)?;
         Ok(config.paused)
     }
+
+    /// Reclaim persistent storage for an escrow that has reached a terminal state
+    /// (Settled, Refunded, or Cancelled). Callable only by the seller or the admin.
+    /// The escrow and its per-funder contribution record are removed permanently;
+    /// terminal-state escrows are never mutated again, so this is safe to prune.
+    pub fn cleanup_escrow(env: Env, invoice_id: Symbol, caller: Address) -> Result<(), Error> {
+        caller.require_auth();
+        let config = storage::get_config(&env).ok_or(Error::NotInit)?;
+        let data = storage::get_escrow(&env, invoice_id.clone()).ok_or(Error::EscrowNotFound)?;
+        if caller != data.seller && caller != config.admin {
+            return Err(Error::Unauthorized);
+        }
+        match data.status {
+            EscrowStatus::Settled | EscrowStatus::Refunded | EscrowStatus::Cancelled => {}
+            _ => return Err(Error::EscrowNotSettled),
+        }
+        if let Some(funder) = &data.funder {
+            storage::set_funder_amount(&env, invoice_id.clone(), funder, 0);
+        }
+        storage::remove_escrow(&env, invoice_id.clone());
+        events::escrow_cleaned_up(&env, invoice_id);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/contracts/invoice-escrow/src/storage.rs
+++ b/contracts/invoice-escrow/src/storage.rs
@@ -31,6 +31,11 @@ pub fn has_escrow(env: &soroban_sdk::Env, inv_id: Symbol) -> bool {
     env.storage().persistent().has(&StorageKey::Escrow(inv_id))
 }
 
+/// Remove escrow data for an invoice from persistent storage (storage footprint cleanup).
+pub fn remove_escrow(env: &soroban_sdk::Env, inv_id: Symbol) {
+    env.storage().persistent().remove(&StorageKey::Escrow(inv_id));
+}
+
 /// Get the amount funded by a specific funder for an invoice.
 pub fn get_funder_amount(
     env: &soroban_sdk::Env,

--- a/contracts/invoice-escrow/src/storage.rs
+++ b/contracts/invoice-escrow/src/storage.rs
@@ -36,6 +36,21 @@ pub fn remove_escrow(env: &soroban_sdk::Env, inv_id: Symbol) {
     env.storage().persistent().remove(&StorageKey::Escrow(inv_id));
 }
 
+/// Get the highest nonce consumed so far for a buyer's signed off-chain approvals.
+pub fn get_nonce(env: &soroban_sdk::Env, buyer: &soroban_sdk::Address) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::Nonce(buyer.clone()))
+        .unwrap_or(0)
+}
+
+/// Record the highest nonce consumed for a buyer's signed off-chain approvals.
+pub fn set_nonce(env: &soroban_sdk::Env, buyer: &soroban_sdk::Address, nonce: u64) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::Nonce(buyer.clone()), &nonce);
+}
+
 /// Get the amount funded by a specific funder for an invoice.
 pub fn get_funder_amount(
     env: &soroban_sdk::Env,

--- a/contracts/invoice-escrow/src/test.rs
+++ b/contracts/invoice-escrow/src/test.rs
@@ -2229,3 +2229,119 @@ fn test_create_escrow_due_date_in_future_accepted() {
     assert_eq!(escrow_data.due_dt, future_due_date);
     assert_eq!(escrow_data.status, EscrowStatus::Created);
 }
+
+#[test]
+fn test_cleanup_escrow_removes_settled_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+
+    let admin = Address::generate(&env);
+    let payment_token_admin = Address::generate(&env);
+    let payment_token_id = env.register_stellar_asset_contract_v2(payment_token_admin.clone());
+    let payment_token = TokenClient::new(&env, &payment_token_id.address());
+    let payment_token_asset = AssetClient::new(&env, &payment_token_id.address());
+    let inv_token_id = env.register(MockInvoiceToken, ());
+
+    escrow_client.initialize(&admin, &300);
+
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "INV_CLEAN1");
+    let amount = 1000;
+
+    payment_token_asset.mint(&buyer, &1000);
+    payment_token_asset.mint(&payer, &1000);
+
+    escrow_client.create_escrow(
+        &invoice_id,
+        &seller,
+        &payer,
+        &amount,
+        &amount,
+        &1000000,
+        &payment_token.address,
+        &inv_token_id,
+        &test_commitment(&env, "cleanup_test"),
+    );
+    escrow_client.fund_escrow(&invoice_id, &buyer, &amount);
+    escrow_client.record_payment(&invoice_id, &payer, &amount);
+    assert_eq!(
+        escrow_client.get_escrow_status(&invoice_id),
+        EscrowStatus::Settled
+    );
+
+    escrow_client.cleanup_escrow(&invoice_id, &seller);
+
+    let result = escrow_client.try_get_escrow(&invoice_id);
+    assert_eq!(result, Err(Ok(Error::EscrowNotFound)));
+}
+
+#[test]
+fn test_cleanup_escrow_rejects_non_terminal_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+
+    let admin = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let payment_token = Address::generate(&env);
+    let inv_token = Address::generate(&env);
+
+    escrow_client.initialize(&admin, &300);
+
+    let invoice_id = Symbol::new(&env, "INV_CLEAN2");
+    escrow_client.create_escrow(
+        &invoice_id,
+        &seller,
+        &seller,
+        &1000,
+        &1000,
+        &1000000,
+        &payment_token,
+        &inv_token,
+        &test_commitment(&env, "cleanup_non_terminal"),
+    );
+
+    let result = escrow_client.try_cleanup_escrow(&invoice_id, &seller);
+    assert_eq!(result, Err(Ok(Error::EscrowNotSettled)));
+}
+
+#[test]
+fn test_cleanup_escrow_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+
+    let admin = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let payment_token = Address::generate(&env);
+    let inv_token = Address::generate(&env);
+
+    escrow_client.initialize(&admin, &300);
+
+    let invoice_id = Symbol::new(&env, "INV_CLEAN3");
+    escrow_client.create_escrow(
+        &invoice_id,
+        &seller,
+        &seller,
+        &1000,
+        &1000,
+        &1000000,
+        &payment_token,
+        &inv_token,
+        &test_commitment(&env, "cleanup_unauthorized"),
+    );
+    escrow_client.cancel_escrow(&invoice_id, &seller);
+
+    let result = escrow_client.try_cleanup_escrow(&invoice_id, &stranger);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}

--- a/contracts/invoice-escrow/src/test.rs
+++ b/contracts/invoice-escrow/src/test.rs
@@ -2231,6 +2231,114 @@ fn test_create_escrow_due_date_in_future_accepted() {
 }
 
 #[test]
+fn test_fund_escrow_signed_succeeds_with_valid_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+
+    let admin = Address::generate(&env);
+    let payment_token_admin = Address::generate(&env);
+    let payment_token_id = env.register_stellar_asset_contract_v2(payment_token_admin.clone());
+    let payment_token = TokenClient::new(&env, &payment_token_id.address());
+    let payment_token_asset = AssetClient::new(&env, &payment_token_id.address());
+    let inv_token_id = env.register(MockInvoiceToken, ());
+
+    escrow_client.initialize(&admin, &300);
+
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "INV_SIG1");
+    let amount = 1000;
+
+    payment_token_asset.mint(&buyer, &2000);
+
+    escrow_client.create_escrow(
+        &invoice_id,
+        &seller,
+        &seller,
+        &amount,
+        &amount,
+        &1000000,
+        &payment_token.address,
+        &inv_token_id,
+        &test_commitment(&env, "signed_fund_test"),
+    );
+
+    // A relayer submits the buyer's off-chain approved funding request with nonce 1.
+    escrow_client.fund_escrow_signed(&invoice_id, &buyer, &amount, &1u64);
+
+    let status = escrow_client.get_escrow_status(&invoice_id);
+    assert_eq!(status, EscrowStatus::Funded);
+    assert_eq!(payment_token.balance(&escrow_id), 1000);
+    assert_eq!(payment_token.balance(&buyer), 1000);
+}
+
+#[test]
+fn test_fund_escrow_signed_rejects_replayed_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+
+    let admin = Address::generate(&env);
+    let payment_token_admin = Address::generate(&env);
+    let payment_token_id = env.register_stellar_asset_contract_v2(payment_token_admin.clone());
+    let payment_token = TokenClient::new(&env, &payment_token_id.address());
+    let payment_token_asset = AssetClient::new(&env, &payment_token_id.address());
+    let inv_token_id = env.register(MockInvoiceToken, ());
+
+    escrow_client.initialize(&admin, &300);
+
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let invoice_id_a = Symbol::new(&env, "INV_SIG2A");
+    let invoice_id_b = Symbol::new(&env, "INV_SIG2B");
+    let amount = 500;
+
+    payment_token_asset.mint(&buyer, &2000);
+
+    escrow_client.create_escrow(
+        &invoice_id_a,
+        &seller,
+        &seller,
+        &amount,
+        &amount,
+        &1000000,
+        &payment_token.address,
+        &inv_token_id,
+        &test_commitment(&env, "signed_fund_replay_a"),
+    );
+    escrow_client.create_escrow(
+        &invoice_id_b,
+        &seller,
+        &seller,
+        &amount,
+        &amount,
+        &1000000,
+        &payment_token.address,
+        &inv_token_id,
+        &test_commitment(&env, "signed_fund_replay_b"),
+    );
+
+    escrow_client.fund_escrow_signed(&invoice_id_a, &buyer, &amount, &1u64);
+
+    // Reusing nonce 1 (even against a different invoice) must be rejected as a replay.
+    let result = escrow_client.try_fund_escrow_signed(&invoice_id_b, &buyer, &amount, &1u64);
+    assert_eq!(result, Err(Ok(Error::NonceAlreadyUsed)));
+
+    // A strictly increasing nonce is accepted.
+    escrow_client.fund_escrow_signed(&invoice_id_b, &buyer, &amount, &2u64);
+    assert_eq!(
+        escrow_client.get_escrow_status(&invoice_id_b),
+        EscrowStatus::Funded
+    );
+}
+
+
+#[test]
 fn test_cleanup_escrow_removes_settled_record() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/invoice-escrow/src/types.rs
+++ b/contracts/invoice-escrow/src/types.rs
@@ -13,6 +13,8 @@ pub enum StorageKey {
     Escrow(soroban_sdk::Symbol),
     /// Persistent: funder amounts by (invoice_id, funder_address).
     FunderAmount(soroban_sdk::Symbol, soroban_sdk::Address),
+    /// Persistent: highest nonce consumed for a signed off-chain approval, by buyer address.
+    Nonce(soroban_sdk::Address),
 }
 
 /// Global contract configuration.

--- a/contracts/invoice-token/src/errors.rs
+++ b/contracts/invoice-token/src/errors.rs
@@ -31,4 +31,6 @@ pub enum Error {
     Paused = 11,
     /// Token decimals exceed the supported sub-asset precision.
     InvalidDecimals = 12,
+    /// Token name or symbol metadata is empty (SEP-41 requires non-empty metadata).
+    InvalidMetadata = 13,
 }

--- a/contracts/invoice-token/src/errors.rs
+++ b/contracts/invoice-token/src/errors.rs
@@ -33,4 +33,6 @@ pub enum Error {
     InvalidDecimals = 12,
     /// Token name or symbol metadata is empty (SEP-41 requires non-empty metadata).
     InvalidMetadata = 13,
+    /// No allowance exists for (from, spender), so its expiration cannot be extended.
+    AllowanceNotFound = 14,
 }

--- a/contracts/invoice-token/src/events.rs
+++ b/contracts/invoice-token/src/events.rs
@@ -57,6 +57,19 @@ pub fn paused_updated_event(env: &Env, old_value: bool, new_value: bool) {
     );
 }
 
+/// Emit an allowance expiration extension (topics ["allowance_extended", from, spender], data new_expiration_ledger).
+pub fn allowance_extended_event(
+    env: &Env,
+    from: &Address,
+    spender: &Address,
+    new_expiration_ledger: u32,
+) {
+    env.events().publish(
+        (Symbol::new(env, "allow_extend"), from, spender),
+        new_expiration_ledger,
+    );
+}
+
 /// Emit a token-decimal configuration update.
 pub fn decimals_updated_event(env: &Env, old_value: u32, new_value: u32) {
     env.events().publish(

--- a/contracts/invoice-token/src/lib.rs
+++ b/contracts/invoice-token/src/lib.rs
@@ -221,6 +221,31 @@ impl InvoiceToken {
         Ok(())
     }
 
+    /// Extend the expiration ledger of an existing allowance without changing its amount.
+    /// Requires `from` auth. The new expiration must be strictly later than the current one,
+    /// and the allowance must not already be expired (use `approve` to reinstate an expired one).
+    pub fn extend_allowance(
+        env: Env,
+        from: Address,
+        spender: Address,
+        new_expiration_ledger: u32,
+    ) -> Result<(), Error> {
+        from.require_auth();
+        storage::get_metadata(&env).ok_or(Error::NotInit)?;
+        let allow =
+            storage::get_allowance_data(&env, &from, &spender).ok_or(Error::AllowanceNotFound)?;
+        let ledger = env.ledger().sequence();
+        if allow.expiration_ledger < ledger {
+            return Err(Error::AllowanceExpired);
+        }
+        if new_expiration_ledger <= allow.expiration_ledger {
+            return Err(Error::InvalidExpiration);
+        }
+        storage::extend_allowance_expiration(&env, &from, &spender, new_expiration_ledger);
+        events::allowance_extended_event(&env, &from, &spender, new_expiration_ledger);
+        Ok(())
+    }
+
     /// Revoke `spender`'s allowance. Requires `from` authorization.
     pub fn revoke_approval(env: Env, from: Address, spender: Address) -> Result<(), Error> {
         from.require_auth();

--- a/contracts/invoice-token/src/lib.rs
+++ b/contracts/invoice-token/src/lib.rs
@@ -37,6 +37,10 @@ impl InvoiceToken {
         if decimals > MAX_DECIMALS {
             return Err(Error::InvalidDecimals);
         }
+        // SEP-41 metadata (name, symbol) must be meaningful, not empty placeholders.
+        if name.is_empty() || symbol.is_empty() {
+            return Err(Error::InvalidMetadata);
+        }
         let meta = TokenMetadata {
             admin: admin.clone(),
             minter: minter.clone(),

--- a/contracts/invoice-token/src/storage.rs
+++ b/contracts/invoice-token/src/storage.rs
@@ -194,3 +194,19 @@ pub fn append_token_history(
     history.push_back(record.clone());
     env.storage().persistent().set(&key, &history);
 }
+
+// ==================== Allowance Expiration Extension ====================
+
+/// Extend the expiration ledger of an existing allowance in place, leaving its amount untouched.
+pub fn extend_allowance_expiration(
+    env: &soroban_sdk::Env,
+    from: &Address,
+    spender: &Address,
+    new_expiration_ledger: u32,
+) {
+    let key = StorageKey::Allowance(from.clone(), spender.clone());
+    if let Some(mut data) = env.storage().persistent().get::<_, AllowanceData>(&key) {
+        data.expiration_ledger = new_expiration_ledger;
+        env.storage().persistent().set(&key, &data);
+    }
+}

--- a/contracts/invoice-token/src/test.rs
+++ b/contracts/invoice-token/src/test.rs
@@ -1312,3 +1312,73 @@ fn test_initialize_rejects_empty_symbol() {
         client.try_initialize(&admin, &name, &empty_symbol, &7u32, &invoice_id, &minter);
     assert_eq!(result, Err(Ok(crate::errors::Error::InvalidMetadata)));
 }
+
+#[test]
+fn test_extend_allowance_updates_expiration_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, minter) = setup_token(&env);
+    let spender = Address::generate(&env);
+
+    client.mint(&admin, &1000, &minter);
+    let expiration = env.ledger().sequence() + 100;
+    client.approve(&admin, &spender, &500, &expiration);
+
+    let new_expiration = expiration + 200;
+    client.extend_allowance(&admin, &spender, &new_expiration);
+
+    // Amount is unchanged; only the expiration ledger moved forward.
+    assert_eq!(client.allowance(&admin, &spender), 500);
+
+    // Ledger advances past the original expiration but before the extended one:
+    // the allowance must still be usable.
+    env.ledger().with_mut(|l| l.sequence_number = expiration + 1);
+    assert_eq!(client.allowance(&admin, &spender), 500);
+}
+
+#[test]
+fn test_extend_allowance_requires_later_expiration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, minter) = setup_token(&env);
+    let spender = Address::generate(&env);
+
+    client.mint(&admin, &1000, &minter);
+    let expiration = env.ledger().sequence() + 100;
+    client.approve(&admin, &spender, &500, &expiration);
+
+    let result = client.try_extend_allowance(&admin, &spender, &expiration);
+    assert_eq!(result, Err(Ok(crate::errors::Error::InvalidExpiration)));
+
+    let result = client.try_extend_allowance(&admin, &spender, &(expiration - 1));
+    assert_eq!(result, Err(Ok(crate::errors::Error::InvalidExpiration)));
+}
+
+#[test]
+fn test_extend_allowance_fails_without_existing_allowance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _minter) = setup_token(&env);
+    let spender = Address::generate(&env);
+
+    let result = client.try_extend_allowance(&admin, &spender, &(env.ledger().sequence() + 100));
+    assert_eq!(result, Err(Ok(crate::errors::Error::AllowanceNotFound)));
+}
+
+#[test]
+fn test_extend_allowance_fails_after_expiry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, minter) = setup_token(&env);
+    let spender = Address::generate(&env);
+
+    client.mint(&admin, &1000, &minter);
+    let current = env.ledger().sequence();
+    let expiration = current + 10;
+    client.approve(&admin, &spender, &500, &expiration);
+
+    // Move past expiration before attempting to extend.
+    env.ledger().with_mut(|l| l.sequence_number = expiration + 1);
+    let result = client.try_extend_allowance(&admin, &spender, &(expiration + 100));
+    assert_eq!(result, Err(Ok(crate::errors::Error::AllowanceExpired)));
+}

--- a/contracts/invoice-token/src/test.rs
+++ b/contracts/invoice-token/src/test.rs
@@ -1281,3 +1281,34 @@ fn test_pause_blocks_burn_and_burn_from() {
     assert_eq!(client.total_supply(), 100);
     assert_eq!(client.allowance(&admin, &spender), 100);
 }
+
+#[test]
+fn test_initialize_rejects_empty_name() {
+    let env = Env::default();
+    let contract_id = env.register(InvoiceToken, ());
+    let client = InvoiceTokenClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let minter = Address::generate(&env);
+    let empty_name = SorobanString::from_str(&env, "");
+    let symbol = SorobanString::from_str(&env, "INV001");
+    let invoice_id = Symbol::new(&env, "inv_001");
+
+    let result = client.try_initialize(&admin, &empty_name, &symbol, &7u32, &invoice_id, &minter);
+    assert_eq!(result, Err(Ok(crate::errors::Error::InvalidMetadata)));
+}
+
+#[test]
+fn test_initialize_rejects_empty_symbol() {
+    let env = Env::default();
+    let contract_id = env.register(InvoiceToken, ());
+    let client = InvoiceTokenClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let minter = Address::generate(&env);
+    let name = SorobanString::from_str(&env, "Invoice INV-001");
+    let empty_symbol = SorobanString::from_str(&env, "");
+    let invoice_id = Symbol::new(&env, "inv_001");
+
+    let result =
+        client.try_initialize(&admin, &name, &empty_symbol, &7u32, &invoice_id, &minter);
+    assert_eq!(result, Err(Ok(crate::errors::Error::InvalidMetadata)));
+}


### PR DESCRIPTION
## Summary
- Invoice Token: enforce SEP-41 metadata trait specification compliance by rejecting empty `name`/`symbol` on `initialize` (Closes #95)
- Invoice Token: add `extend_allowance` to push out an existing allowance's expiration ledger without changing its amount (Closes #99)
- Invoice Escrow: add `fund_escrow_signed` with nonce-based replay protection for relayer-submitted off-chain approvals (Closes #93)
- Invoice Escrow: add `cleanup_escrow` to reclaim persistent storage for terminal-state escrow records (Closes #94)

## Test plan
- [x] New unit tests added per issue, covering success and failure paths (empty metadata, allowance extension edge cases, nonce replay/ordering, cleanup authorization and terminal-state checks)
- [ ] CI checks (build, tests, clippy/fmt) pass on this PR

Closes #93 
Closes #94 
Closes #95 
Closes #99