### PR TITLE
Payment Distributor: TTL renewal, escrow whitelist, dry-run fee getter

### DIFF
--- a/contracts/payment-distributor/src/errors.rs
+++ b/contracts/payment-distributor/src/errors.rs
@@ -29,4 +29,8 @@ pub enum Error {
     AssetMismatch = 16,
     /// The contract holds no balance to withdraw. Issue #125.
     NothingToWithdraw = 17,
+    /// No escrow contract has been whitelisted yet (Issue #121 / #131).
+    EscrowContractNotSet = 18,
+    /// Caller is not the whitelisted escrow contract (Issue #131).
+    UnauthorizedEscrowOrigin = 19,
 }

--- a/contracts/payment-distributor/src/events.rs
+++ b/contracts/payment-distributor/src/events.rs
@@ -18,10 +18,10 @@ pub fn fee_recipient_updated(env: &Env, old_recipient: Option<Address>, new_reci
 /// Event structure:
 /// - Topics: (PaymentDistributed, escrow_address, invoice_id)
 /// - Data: (
-///     recipients: Vec<Address>,  // [seller, funder, fee_recipient]
-///     amounts: Vec<i128>,        // [seller_amount, investor_amount, platform_fee, total_paid]
-///     escrow_status: u32,        // Current escrow status
-///     timestamp: u64             // Ledger timestamp
+///   recipients: Vec<Address>,  // [seller, funder, fee_recipient]
+///   amounts: Vec<i128>,        // [seller_amount, investor_amount, platform_fee, total_paid]
+///   escrow_status: u32,        // Current escrow status
+///   timestamp: u64             // Ledger timestamp
 ///   )
 pub fn payment_distributed(
     env: &Env,
@@ -83,6 +83,14 @@ pub fn asset_distributed(
     let topics = (Symbol::new(env, "AssetDistributed"), token.clone());
     env.events()
         .publish(topics, (recipients.clone(), amounts.clone(), total));
+}
+
+/// Issue #121: Whitelisted escrow contract binding updated event.
+/// Topics: (escrow_contract_updated,); Data: (old_escrow, new_escrow).
+pub fn escrow_contract_updated(env: &Env, old_escrow: Option<Address>, new_escrow: &Address) {
+    let topics = (Symbol::new(env, "escrow_contract_updated"),);
+    env.events()
+        .publish(topics, (old_escrow, new_escrow.clone()));
 }
 
 /// Issue #125: Emergency withdrawal audit event.

--- a/contracts/payment-distributor/src/integration_test.rs
+++ b/contracts/payment-distributor/src/integration_test.rs
@@ -60,6 +60,7 @@ fn setup(env: &Env, fee_bps: u32, configure_distributor: bool) -> FlowContext<'_
 
     escrow.initialize(&admin, &fee_bps);
     distributor.initialize(&admin);
+    distributor.set_escrow_contract(&admin, &escrow_id);
     if configure_distributor {
         escrow.set_payment_distributor(&distributor_id);
     }

--- a/contracts/payment-distributor/src/lib.rs
+++ b/contracts/payment-distributor/src/lib.rs
@@ -5,7 +5,7 @@ mod events;
 mod storage;
 mod types;
 
-pub use types::{AssetRoute, DistributionSplit, DistributionState};
+pub use types::{AssetRoute, DistributionQuote, DistributionSplit, DistributionState};
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env, Symbol, Vec};
 
@@ -164,6 +164,12 @@ impl PaymentDistributor {
 
         storage::get_admin(&env).ok_or(Error::NotInit)?;
         escrow_contract.require_auth();
+
+        // Issue #131: Only the whitelisted escrow contract may invoke distribution.
+        let whitelisted = storage::get_escrow_contract(&env).ok_or(Error::EscrowContractNotSet)?;
+        if escrow_contract != whitelisted {
+            return Err(Error::UnauthorizedEscrowOrigin);
+        }
 
         if escrow_status != ESCROW_STATUS_FUNDED && escrow_status != ESCROW_STATUS_SETTLED {
             return Err(Error::InvalidEscrowStatus);
@@ -426,6 +432,98 @@ impl PaymentDistributor {
     ) -> Result<types::DistributionState, Error> {
         storage::get_admin(&env).ok_or(Error::NotInit)?;
         Ok(get_distribution_state(&env, &escrow_contract, &invoice_id))
+    }
+
+    /// Issue #121: Bind (or rebind) the whitelisted escrow contract address
+    /// authorized to invoke distribution entrypoints. Admin-only.
+    pub fn set_escrow_contract(
+        env: Env,
+        admin: Address,
+        escrow_contract: Address,
+    ) -> Result<(), Error> {
+        let stored_admin = storage::get_admin(&env).ok_or(Error::NotInit)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        admin.require_auth();
+
+        let old_escrow = storage::get_escrow_contract(&env);
+        storage::set_escrow_contract(&env, &escrow_contract);
+        events::escrow_contract_updated(&env, old_escrow, &escrow_contract);
+        Ok(())
+    }
+
+    /// View: return the whitelisted escrow contract address, if configured.
+    pub fn get_escrow_contract(env: Env) -> Result<Address, Error> {
+        storage::get_admin(&env).ok_or(Error::NotInit)?;
+        storage::get_escrow_contract(&env).ok_or(Error::EscrowContractNotSet)
+    }
+
+    /// Issue #129: Dry-run the `distribute_payment` fee/split calculation
+    /// without touching storage or moving funds. Mirrors the exact math of
+    /// `distribute_payment` so callers can preview amounts before submitting.
+    pub fn calculate_distribution_splits(
+        env: Env,
+        escrow_contract: Address,
+        invoice_id: Symbol,
+        addresses: Vec<Address>,
+        amounts: Vec<i128>,
+    ) -> Result<types::DistributionQuote, Error> {
+        storage::get_admin(&env).ok_or(Error::NotInit)?;
+
+        if addresses.len() != 4 || amounts.len() != 4 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let fee_bps_u32 = amounts.get(3).ok_or(Error::InvalidAmount)? as u32;
+        if fee_bps_u32 > MAX_FEE_BPS {
+            return Err(Error::InvalidBps);
+        }
+
+        let paid_amount = amounts.get(0).ok_or(Error::InvalidAmount)?;
+        let state = get_distribution_state(&env, &escrow_contract, &invoice_id);
+        let payment_amount = paid_amount
+            .checked_sub(state.paid_distributed)
+            .ok_or(Error::Overflow)?;
+
+        if payment_amount <= 0 {
+            return Err(Error::NothingToDistribute);
+        }
+
+        let platform_fee = (payment_amount as i128)
+            .checked_mul(fee_bps_u32 as i128)
+            .ok_or(Error::Overflow)?
+            .checked_div(10_000)
+            .ok_or(Error::Overflow)?;
+
+        let investor_amount = amounts.get(2).ok_or(Error::InvalidAmount)?;
+
+        let seller_amount = payment_amount
+            .checked_sub(investor_amount)
+            .ok_or(Error::Overflow)?
+            .checked_sub(platform_fee)
+            .ok_or(Error::Overflow)?;
+
+        if seller_amount < 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let total_distribution = seller_amount
+            .checked_add(investor_amount)
+            .ok_or(Error::Overflow)?
+            .checked_add(platform_fee)
+            .ok_or(Error::Overflow)?;
+
+        if total_distribution != payment_amount {
+            return Err(Error::InvalidAmount);
+        }
+
+        Ok(types::DistributionQuote {
+            seller_amount,
+            investor_amount,
+            platform_fee,
+            payment_amount,
+        })
     }
 }
 

--- a/contracts/payment-distributor/src/storage.rs
+++ b/contracts/payment-distributor/src/storage.rs
@@ -2,6 +2,24 @@ use soroban_sdk::{Address, Env, Symbol};
 
 use crate::types::{DistributionState, StorageKey};
 
+/// Ledgers below which a `Distribution` persistent entry's TTL is extended
+/// (~7 days at 5s/ledger). Issue #128.
+const TTL_THRESHOLD: u32 = 120_960;
+/// Ledgers to extend a `Distribution` persistent entry's TTL to when bumped
+/// (~30 days at 5s/ledger). Issue #128.
+const TTL_EXTEND_TO: u32 = 518_400;
+
+/// Extend the TTL of a distribution's persistent storage entry so it survives
+/// ledger pruning across the full lifetime of a long-lived invoice fee
+/// schedule. Issue #128.
+pub fn extend_ttl(env: &Env, escrow: &Address, invoice_id: &Symbol) {
+    env.storage().persistent().extend_ttl(
+        &StorageKey::Distribution(escrow.clone(), invoice_id.clone()),
+        TTL_THRESHOLD,
+        TTL_EXTEND_TO,
+    );
+}
+
 pub fn set_admin(env: &Env, admin: &Address) {
     env.storage().instance().set(&StorageKey::Admin, admin);
 }
@@ -37,10 +55,14 @@ pub fn get_distribution(
     escrow: &Address,
     invoice_id: &Symbol,
 ) -> Option<DistributionState> {
-    env.storage().persistent().get(&StorageKey::Distribution(
+    let data = env.storage().persistent().get(&StorageKey::Distribution(
         escrow.clone(),
         invoice_id.clone(),
-    ))
+    ));
+    if data.is_some() {
+        extend_ttl(env, escrow, invoice_id);
+    }
+    data
 }
 
 pub fn set_distribution(
@@ -53,4 +75,18 @@ pub fn set_distribution(
         &StorageKey::Distribution(escrow.clone(), invoice_id.clone()),
         state,
     );
+    extend_ttl(env, escrow, invoice_id);
+}
+
+/// Set the whitelisted escrow contract address authorized to invoke
+/// distribution entrypoints. Admin-only. Issue #121.
+pub fn set_escrow_contract(env: &Env, escrow_contract: &Address) {
+    env.storage()
+        .instance()
+        .set(&StorageKey::EscrowContract, escrow_contract);
+}
+
+/// Get the whitelisted escrow contract address, if configured. Issue #121.
+pub fn get_escrow_contract(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&StorageKey::EscrowContract)
 }

--- a/contracts/payment-distributor/src/test.rs
+++ b/contracts/payment-distributor/src/test.rs
@@ -60,6 +60,7 @@ fn setup(env: &Env, fee_bps: u32, configure_distributor: bool) -> TestContext<'_
 
     escrow.initialize(&admin, &fee_bps);
     distributor.initialize(&admin);
+    distributor.set_escrow_contract(&admin, &escrow_id);
     if configure_distributor {
         escrow.set_payment_distributor(&distributor_id);
     }
@@ -665,6 +666,7 @@ fn test_reentrant_callback_into_distribute_payment_is_rejected() {
     let funder = Address::generate(&env);
     let escrow = Address::generate(&env);
     let invoice_id = Symbol::new(&env, "REENTR");
+    distributor.set_escrow_contract(&admin, &escrow);
 
     // Register the malicious token that will re-enter on `transfer`.
     let token_id = env.register(
@@ -992,4 +994,258 @@ fn test_emergency_withdraw_empty_balance_rejected() {
     let result = distributor.try_emergency_withdraw(&admin, &token.address, &safe);
 
     assert_eq!(result, Err(Ok(Error::NothingToWithdraw)));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Issue #128: Storage key TTL renewal for fee schedules (Distribution entries)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_distribution_ttl_extended_on_write_and_read() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ctx = setup(&env, 300, true);
+    create_and_fund(&ctx, 1_000, 50_000);
+    ctx.payment_asset.mint(&ctx.payer, &1_000);
+    ctx.escrow
+        .record_payment(&ctx.invoice_id, &ctx.payer, &1_000);
+
+    // Fast-forward past the TTL threshold so the entry would be pruneable if
+    // its TTL were never bumped, then read it again.
+    env.ledger().with_mut(|l| {
+        l.sequence_number += 130_000;
+    });
+
+    let state = ctx
+        .distributor
+        .get_distribution_state(&ctx.escrow_id, &ctx.invoice_id);
+    assert_eq!(state.paid_distributed, 1_000);
+
+    let ttl = env.as_contract(&ctx.distributor_id, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&crate::types::StorageKey::Distribution(
+                ctx.escrow_id.clone(),
+                ctx.invoice_id.clone(),
+            ))
+    });
+    assert!(ttl >= 500_000);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Issue #121: Dynamic escrow contract address binding
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_set_and_get_escrow_contract_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _distributor_id, distributor) = distributor_only(&env);
+    let escrow = Address::generate(&env);
+
+    distributor.set_escrow_contract(&admin, &escrow);
+    assert_eq!(distributor.get_escrow_contract(), escrow);
+}
+
+#[test]
+fn test_set_escrow_contract_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, _distributor_id, distributor) = distributor_only(&env);
+    let attacker = Address::generate(&env);
+    let escrow = Address::generate(&env);
+
+    let result = distributor.try_set_escrow_contract(&attacker, &escrow);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_get_escrow_contract_unset_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, _distributor_id, distributor) = distributor_only(&env);
+    let result = distributor.try_get_escrow_contract();
+    assert_eq!(result, Err(Ok(Error::EscrowContractNotSet)));
+}
+
+#[test]
+fn test_escrow_contract_rebinding_emits_update() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _distributor_id, distributor) = distributor_only(&env);
+    let escrow_a = Address::generate(&env);
+    let escrow_b = Address::generate(&env);
+
+    distributor.set_escrow_contract(&admin, &escrow_a);
+    distributor.set_escrow_contract(&admin, &escrow_b);
+    assert_eq!(distributor.get_escrow_contract(), escrow_b);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Issue #131: Whitelisted escrow origin filter enforcement on distribute_payment
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_distribute_payment_rejects_unwhitelisted_escrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _distributor_id, distributor) = distributor_only(&env);
+    let whitelisted_escrow = Address::generate(&env);
+    distributor.set_escrow_contract(&admin, &whitelisted_escrow);
+
+    let rogue_escrow = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "ROGUE");
+    let (token, _asset) = make_token(&env);
+
+    let result = distributor.try_distribute_payment(
+        &rogue_escrow,
+        &invoice_id,
+        &soroban_sdk::vec![&env, token.address.clone(), seller, funder, admin],
+        &soroban_sdk::vec![&env, 100i128, 100i128, 0i128, 0i128],
+        &2u32,
+    );
+
+    assert_eq!(result, Err(Ok(Error::UnauthorizedEscrowOrigin)));
+}
+
+#[test]
+fn test_distribute_payment_rejects_when_escrow_contract_not_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _distributor_id, distributor) = distributor_only(&env);
+    let escrow = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "NOESCROW");
+    let (token, _asset) = make_token(&env);
+
+    let result = distributor.try_distribute_payment(
+        &escrow,
+        &invoice_id,
+        &soroban_sdk::vec![&env, token.address.clone(), seller, funder, admin],
+        &soroban_sdk::vec![&env, 100i128, 100i128, 0i128, 0i128],
+        &2u32,
+    );
+
+    assert_eq!(result, Err(Ok(Error::EscrowContractNotSet)));
+}
+
+#[test]
+fn test_distribute_payment_succeeds_for_whitelisted_escrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ctx = setup(&env, 300, true);
+    create_and_fund(&ctx, 1_000, 50_000);
+    ctx.payment_asset.mint(&ctx.payer, &1_000);
+    ctx.escrow
+        .record_payment(&ctx.invoice_id, &ctx.payer, &1_000);
+
+    let state = ctx
+        .distributor
+        .get_distribution_state(&ctx.escrow_id, &ctx.invoice_id);
+    assert_eq!(state.paid_distributed, 1_000);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Issue #129: Distributor fee calculation dry-run getter
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_calculate_distribution_splits_matches_actual_distribution() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ctx = setup(&env, 500, true);
+    create_and_fund(&ctx, 1_000, 50_000);
+    ctx.payment_asset.mint(&ctx.payer, &1_000);
+
+    let addresses = soroban_sdk::vec![
+        &env,
+        ctx.payment_token.address.clone(),
+        ctx.seller.clone(),
+        ctx.buyer.clone(),
+        ctx.admin.clone()
+    ];
+    let amounts = soroban_sdk::vec![&env, 1_000i128, 0i128, 0i128, 500u32 as i128];
+
+    let quote = ctx.distributor.calculate_distribution_splits(
+        &ctx.escrow_id,
+        &ctx.invoice_id,
+        &addresses,
+        &amounts,
+    );
+
+    // 5% of 1000 = 50 platform fee, 0 investor amount, seller absorbs the rest.
+    assert_eq!(quote.platform_fee, 50);
+    assert_eq!(quote.investor_amount, 0);
+    assert_eq!(quote.seller_amount, 950);
+    assert_eq!(quote.payment_amount, 1_000);
+
+    // The dry-run must not have mutated any storage: state stays untouched.
+    let state = ctx
+        .distributor
+        .get_distribution_state(&ctx.escrow_id, &ctx.invoice_id);
+    assert_eq!(state.paid_distributed, 0);
+}
+
+#[test]
+fn test_calculate_distribution_splits_rejects_invalid_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ctx = setup(&env, 300, true);
+
+    let addresses = soroban_sdk::vec![
+        &env,
+        ctx.payment_token.address.clone(),
+        ctx.seller.clone(),
+        ctx.buyer.clone(),
+        ctx.admin.clone()
+    ];
+    let amounts = soroban_sdk::vec![&env, 1_000i128, 0i128, 0i128, 10_001i128];
+
+    let result = ctx.distributor.try_calculate_distribution_splits(
+        &ctx.escrow_id,
+        &ctx.invoice_id,
+        &addresses,
+        &amounts,
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidBps)));
+}
+
+#[test]
+fn test_calculate_distribution_splits_rejects_nothing_to_distribute() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ctx = setup(&env, 300, true);
+
+    let addresses = soroban_sdk::vec![
+        &env,
+        ctx.payment_token.address.clone(),
+        ctx.seller.clone(),
+        ctx.buyer.clone(),
+        ctx.admin.clone()
+    ];
+    let amounts = soroban_sdk::vec![&env, 0i128, 0i128, 0i128, 300i128];
+
+    let result = ctx.distributor.try_calculate_distribution_splits(
+        &ctx.escrow_id,
+        &ctx.invoice_id,
+        &addresses,
+        &amounts,
+    );
+
+    assert_eq!(result, Err(Ok(Error::NothingToDistribute)));
 }

--- a/contracts/payment-distributor/src/types.rs
+++ b/contracts/payment-distributor/src/types.rs
@@ -11,6 +11,9 @@ pub enum StorageKey {
     FeeRecipient,
     /// Re-entrancy guard flag for distribution entrypoints (Issue #127).
     Locked,
+    /// Whitelisted escrow contract address authorized to invoke distribution
+    /// entrypoints (Issue #121 / #131).
+    EscrowContract,
 }
 
 #[contracttype]
@@ -85,4 +88,15 @@ pub struct AssetRoute {
     pub token: Address,
     pub amount: i128,
     pub split: DistributionSplit,
+}
+
+/// Dry-run result of a `distribute_payment` fee/split calculation, computed
+/// without touching storage or moving funds (Issue #129).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DistributionQuote {
+    pub seller_amount: i128,
+    pub investor_amount: i128,
+    pub platform_fee: i128,
+    pub payment_amount: i128,
 }


### PR DESCRIPTION
## Summary
Closes #128, 
Closs #121 Closes #131 , Closes #129 
.

- **#128** - `storage::extend_ttl` renews the TTL on `Distribution` persistent entries every time they're read or written (7-day threshold / 30-day extension, matching the existing `invoice-escrow` pattern), so fee-schedule data on long-lived invoices survives ledger pruning.
- **#121** - Adds `StorageKey::EscrowContract` plus admin-only `set_escrow_contract` / `get_escrow_contract` entrypoints to bind the escrow contract address authorized to call distribution entrypoints.
- **#131** - `distribute_payment` now enforces that the calling `escrow_contract` matches the whitelisted address from #121, rejecting unbound (`EscrowContractNotSet`) or mismatched (`UnauthorizedEscrowOrigin`) callers.
- **#129** - Adds `calculate_distribution_splits`, a read-only dry-run getter that mirrors `distribute_payment`'s exact fee/split math (seller/investor/platform-fee amounts) without touching storage or moving funds, so integrators can preview a distribution before submitting it.

New error variants: `EscrowContractNotSet`, `UnauthorizedEscrowOrigin`. New type: `DistributionQuote`. New event: `escrow_contract_updated`.

Existing test `setup()` helpers (`test.rs`, `integration_test.rs`) now call `set_escrow_contract` so pre-existing tests keep passing under the new whitelist enforcement.

## Known environment blocker (unrelated to this PR)
`cargo test -p payment-distributor` currently cannot complete in this environment: `payment-distributor`'s test suite dev-depends on `invoice-token` and `invoice-escrow`, and both currently fail to compile on `dev` HEAD (pre-existing breakage from a separate, already-merged change - e.g. `invoice-token`'s `errors.rs` is missing several `Error` variants its own `lib.rs` references). This reproduces identically on a clean `dev` checkout with no changes applied, so it is not introduced by this PR.

Verified instead via:
- `cargo check -p payment-distributor --lib` - clean
- `cargo clippy -p payment-distributor --lib -- -D warnings` - clean
- `cargo fmt -p payment-distributor -- --check` - clean

New unit tests are included in `test.rs` (TTL extension via ledger fast-forward + `get_ttl` assertion, escrow whitelist set/get/unauthorized/unset paths, `distribute_payment` origin rejection, and `calculate_distribution_splits` success/invalid-bps/nothing-to-distribute paths) and should pass once the unrelated `invoice-token`/`invoice-escrow` compile errors are fixed upstream.

## Test plan
- [x] cargo check -p payment-distributor --lib
- [x] cargo clippy -p payment-distributor --lib -- -D warnings
- [x] cargo fmt -p payment-distributor -- --check
- [ ] cargo test -p payment-distributor - blocked by pre-existing invoice-token/invoice-escrow compile errors on dev, unrelated to this change
