### PR TITLE
feat(payment-distributor): escrow whitelist binding + dry-run split getter

### DIFF
--- a/contracts/payment-distributor/src/errors.rs
+++ b/contracts/payment-distributor/src/errors.rs
@@ -29,4 +29,6 @@ pub enum Error {
     AssetMismatch = 16,
     /// The contract holds no balance to withdraw. Issue #125.
     NothingToWithdraw = 17,
+    /// The calling escrow contract does not match the whitelisted escrow address. Issue #131.
+    UnauthorizedEscrow = 18,
 }

--- a/contracts/payment-distributor/src/events.rs
+++ b/contracts/payment-distributor/src/events.rs
@@ -12,6 +12,13 @@ pub fn fee_recipient_updated(env: &Env, old_recipient: Option<Address>, new_reci
         .publish(topics, (old_recipient, new_recipient.clone()));
 }
 
+/// Issue #121: Escrow contract binding updated event.
+pub fn escrow_contract_updated(env: &Env, old_escrow: Option<Address>, new_escrow: &Address) {
+    let topics = (Symbol::new(env, "escrow_contract_updated"),);
+    env.events()
+        .publish(topics, (old_escrow, new_escrow.clone()));
+}
+
 /// Issue #123: Enhanced structured payment distribution audit event.
 /// Emits comprehensive distribution details for compliance and audit trails.
 ///

--- a/contracts/payment-distributor/src/lib.rs
+++ b/contracts/payment-distributor/src/lib.rs
@@ -5,7 +5,7 @@ mod events;
 mod storage;
 mod types;
 
-pub use types::{AssetRoute, DistributionSplit, DistributionState};
+pub use types::{AssetRoute, DistributionPreview, DistributionSplit, DistributionState};
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env, Symbol, Vec};
 
@@ -47,6 +47,65 @@ fn acquire_lock(env: &Env) -> Result<(), Error> {
 /// Issue #127: Release the re-entrancy lock on normal completion.
 fn release_lock(env: &Env) {
     storage::set_lock(env, false);
+}
+
+/// Issue #129: Shared split-calculation core used by both `distribute_payment`
+/// and the `calculate_distribution_splits` dry-run getter. Computes the
+/// seller/investor/fee split for a payment delta with no storage writes or
+/// token transfers.
+///
+/// Issue #132: Rounding losses are allocated to the seller so the total
+/// distribution equals `payment_amount` exactly.
+fn compute_split(
+    paid_amount: i128,
+    already_distributed: i128,
+    investor_amount: i128,
+    fee_bps_u32: u32,
+) -> Result<types::DistributionPreview, Error> {
+    if fee_bps_u32 > MAX_FEE_BPS {
+        return Err(Error::InvalidBps);
+    }
+
+    let payment_amount = paid_amount
+        .checked_sub(already_distributed)
+        .ok_or(Error::Overflow)?;
+
+    if payment_amount <= 0 {
+        return Err(Error::NothingToDistribute);
+    }
+
+    let platform_fee = payment_amount
+        .checked_mul(fee_bps_u32 as i128)
+        .ok_or(Error::Overflow)?
+        .checked_div(10_000)
+        .ok_or(Error::Overflow)?;
+
+    let seller_amount = payment_amount
+        .checked_sub(investor_amount)
+        .ok_or(Error::Overflow)?
+        .checked_sub(platform_fee)
+        .ok_or(Error::Overflow)?;
+
+    if seller_amount < 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    let total_distribution = seller_amount
+        .checked_add(investor_amount)
+        .ok_or(Error::Overflow)?
+        .checked_add(platform_fee)
+        .ok_or(Error::Overflow)?;
+
+    if total_distribution != payment_amount {
+        return Err(Error::InvalidAmount);
+    }
+
+    Ok(types::DistributionPreview {
+        seller_amount,
+        investor_amount,
+        platform_fee,
+        total_distribution,
+    })
 }
 
 /// Issue #126 / #130: Distribute a single asset `amount` across `split`, taking the
@@ -165,6 +224,15 @@ impl PaymentDistributor {
         storage::get_admin(&env).ok_or(Error::NotInit)?;
         escrow_contract.require_auth();
 
+        // Issue #131: Opt-in whitelist enforcement. If no escrow contract has been
+        // bound via `set_escrow_contract`, behavior is unchanged (open). Once bound,
+        // only that exact address may call `distribute_payment`.
+        if let Some(whitelisted) = storage::get_escrow_contract(&env) {
+            if whitelisted != escrow_contract {
+                return Err(Error::UnauthorizedEscrow);
+            }
+        }
+
         if escrow_status != ESCROW_STATUS_FUNDED && escrow_status != ESCROW_STATUS_SETTLED {
             return Err(Error::InvalidEscrowStatus);
         }
@@ -177,53 +245,20 @@ impl PaymentDistributor {
         let funder = addresses.get(2).ok_or(Error::InvalidAmount)?;
         let fee_bps_u32 = amounts.get(3).ok_or(Error::InvalidAmount)? as u32;
 
-        // Issue #124: Validate fee BPS does not exceed maximum (10,000 = 100%)
-        if fee_bps_u32 > MAX_FEE_BPS {
-            return Err(Error::InvalidBps);
-        }
-
         let paid_amount = amounts.get(0).ok_or(Error::InvalidAmount)?;
-        let mut state = get_distribution_state(&env, &escrow_contract, &invoice_id);
-        let payment_amount = paid_amount
-            .checked_sub(state.paid_distributed)
-            .ok_or(Error::Overflow)?;
-
-        if payment_amount <= 0 {
-            return Err(Error::NothingToDistribute);
-        }
-
-        // Issue #132: Automated fee rounding loss minimization
-        // Calculate platform fee, investor amount, then allocate any rounding loss to seller
-        let platform_fee = (payment_amount as i128)
-            .checked_mul(fee_bps_u32 as i128)
-            .ok_or(Error::Overflow)?
-            .checked_div(10_000)
-            .ok_or(Error::Overflow)?;
-
         let investor_amount = amounts.get(2).ok_or(Error::InvalidAmount)?;
+        let mut state = get_distribution_state(&env, &escrow_contract, &invoice_id);
 
-        // Seller receives: payment_amount - investor_amount - platform_fee
-        // This automatically absorbs any rounding loss
-        let seller_amount = payment_amount
-            .checked_sub(investor_amount)
-            .ok_or(Error::Overflow)?
-            .checked_sub(platform_fee)
-            .ok_or(Error::Overflow)?;
-
-        if seller_amount < 0 {
-            return Err(Error::InvalidAmount);
-        }
-
-        // Verify total distribution equals payment_amount exactly
-        let total_distribution = seller_amount
-            .checked_add(investor_amount)
-            .ok_or(Error::Overflow)?
-            .checked_add(platform_fee)
-            .ok_or(Error::Overflow)?;
-
-        if total_distribution != payment_amount {
-            return Err(Error::InvalidAmount);
-        }
+        // Issue #132: Automated fee rounding loss minimization, computed via the
+        // shared `compute_split` core also used by the Issue #129 dry-run getter.
+        let preview = compute_split(
+            paid_amount,
+            state.paid_distributed,
+            investor_amount,
+            fee_bps_u32,
+        )?;
+        let platform_fee = preview.platform_fee;
+        let seller_amount = preview.seller_amount;
 
         // Issue #122: Use configured fee recipient (fallback to admin if not set)
         let fee_recipient = storage::get_fee_recipient(&env)
@@ -426,6 +461,57 @@ impl PaymentDistributor {
     ) -> Result<types::DistributionState, Error> {
         storage::get_admin(&env).ok_or(Error::NotInit)?;
         Ok(get_distribution_state(&env, &escrow_contract, &invoice_id))
+    }
+
+    /// Issue #121: Bind the whitelisted escrow contract address allowed to call
+    /// `distribute_payment`. Only the admin can update this binding.
+    /// Emits an `escrow_contract_updated` event for audit trails.
+    pub fn set_escrow_contract(env: Env, admin: Address, new_escrow: Address) -> Result<(), Error> {
+        let stored_admin = storage::get_admin(&env).ok_or(Error::NotInit)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        admin.require_auth();
+
+        let old_escrow = storage::get_escrow_contract(&env);
+        storage::set_escrow_contract(&env, &new_escrow);
+        events::escrow_contract_updated(&env, old_escrow, &new_escrow);
+        Ok(())
+    }
+
+    /// View: return the currently whitelisted escrow contract, if any bound.
+    pub fn get_escrow_contract(env: Env) -> Result<Option<Address>, Error> {
+        storage::get_admin(&env).ok_or(Error::NotInit)?;
+        Ok(storage::get_escrow_contract(&env))
+    }
+
+    /// Issue #129: Dry-run preview of a `distribute_payment` split. Performs no
+    /// storage writes, no token transfers, and no auth checks — a pure view
+    /// into what `distribute_payment` would compute for the same inputs.
+    pub fn calculate_distribution_splits(
+        env: Env,
+        escrow_contract: Address,
+        invoice_id: Symbol,
+        addresses: Vec<Address>,
+        amounts: Vec<i128>,
+    ) -> Result<DistributionPreview, Error> {
+        storage::get_admin(&env).ok_or(Error::NotInit)?;
+
+        if addresses.len() != 4 || amounts.len() != 4 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let fee_bps_u32 = amounts.get(3).ok_or(Error::InvalidAmount)? as u32;
+        let paid_amount = amounts.get(0).ok_or(Error::InvalidAmount)?;
+        let investor_amount = amounts.get(2).ok_or(Error::InvalidAmount)?;
+        let state = get_distribution_state(&env, &escrow_contract, &invoice_id);
+
+        compute_split(
+            paid_amount,
+            state.paid_distributed,
+            investor_amount,
+            fee_bps_u32,
+        )
     }
 }
 

--- a/contracts/payment-distributor/src/storage.rs
+++ b/contracts/payment-distributor/src/storage.rs
@@ -20,6 +20,17 @@ pub fn get_fee_recipient(env: &Env) -> Option<Address> {
     env.storage().instance().get(&StorageKey::FeeRecipient)
 }
 
+/// Whitelisted escrow contract address accessors (Issue #121).
+pub fn set_escrow_contract(env: &Env, escrow_contract: &Address) {
+    env.storage()
+        .instance()
+        .set(&StorageKey::EscrowContract, escrow_contract);
+}
+
+pub fn get_escrow_contract(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&StorageKey::EscrowContract)
+}
+
 /// Re-entrancy guard flag accessors (Issue #127).
 pub fn is_locked(env: &Env) -> bool {
     env.storage()

--- a/contracts/payment-distributor/src/test.rs
+++ b/contracts/payment-distributor/src/test.rs
@@ -993,3 +993,233 @@ fn test_emergency_withdraw_empty_balance_rejected() {
 
     assert_eq!(result, Err(Ok(Error::NothingToWithdraw)));
 }
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Issue #121: Dynamic Escrow Contract Address Binding
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_set_escrow_contract_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _distributor_id, distributor) = distributor_only(&env);
+    let escrow = Address::generate(&env);
+
+    assert_eq!(distributor.get_escrow_contract(), None);
+    distributor.set_escrow_contract(&admin, &escrow);
+    assert_eq!(distributor.get_escrow_contract(), Some(escrow));
+}
+
+#[test]
+fn test_set_escrow_contract_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, _distributor_id, distributor) = distributor_only(&env);
+    let attacker = Address::generate(&env);
+    let escrow = Address::generate(&env);
+
+    let result = distributor.try_set_escrow_contract(&attacker, &escrow);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    assert_eq!(distributor.get_escrow_contract(), None);
+}
+
+#[test]
+fn test_set_escrow_contract_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _distributor_id, distributor) = distributor_only(&env);
+    let escrow = Address::generate(&env);
+
+    distributor.set_escrow_contract(&admin, &escrow);
+
+    let events = env.events().all();
+    assert!(events.len() > 0);
+}
+
+#[test]
+fn test_get_escrow_contract_requires_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let distributor_id = env.register(PaymentDistributor, ());
+    let distributor = PaymentDistributorClient::new(&env, &distributor_id);
+
+    let result = distributor.try_get_escrow_contract();
+    assert_eq!(result, Err(Ok(Error::NotInit)));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Issue #131: Whitelisted Escrow Origin Filter Enforcement
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_distribute_payment_open_when_no_escrow_bound() {
+    // Backward-compatible: with no escrow whitelisted, any caller (that can produce
+    // escrow_contract auth) may still call distribute_payment.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _distributor_id, distributor) = distributor_only(&env);
+    let escrow = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "OPEN");
+    let (token, asset) = make_token(&env);
+    asset.mint(&escrow, &100);
+
+    let result = distributor.try_distribute_payment(
+        &escrow,
+        &invoice_id,
+        &soroban_sdk::vec![&env, token.address.clone(), seller, funder, admin],
+        &soroban_sdk::vec![&env, 100i128, 100i128, 0i128, 0i128],
+        &2u32,
+    );
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_distribute_payment_accepts_whitelisted_escrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _distributor_id, distributor) = distributor_only(&env);
+    let escrow = Address::generate(&env);
+    distributor.set_escrow_contract(&admin, &escrow);
+
+    let seller = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "WL_OK");
+    let (token, asset) = make_token(&env);
+    asset.mint(&escrow, &100);
+
+    let result = distributor.try_distribute_payment(
+        &escrow,
+        &invoice_id,
+        &soroban_sdk::vec![&env, token.address.clone(), seller, funder, admin],
+        &soroban_sdk::vec![&env, 100i128, 100i128, 0i128, 0i128],
+        &2u32,
+    );
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_distribute_payment_rejects_non_whitelisted_escrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _distributor_id, distributor) = distributor_only(&env);
+    let whitelisted_escrow = Address::generate(&env);
+    distributor.set_escrow_contract(&admin, &whitelisted_escrow);
+
+    let other_escrow = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "WL_BAD");
+    let (token, asset) = make_token(&env);
+    asset.mint(&other_escrow, &100);
+
+    let result = distributor.try_distribute_payment(
+        &other_escrow,
+        &invoice_id,
+        &soroban_sdk::vec![&env, token.address.clone(), seller, funder, admin],
+        &soroban_sdk::vec![&env, 100i128, 100i128, 0i128, 0i128],
+        &2u32,
+    );
+
+    assert_eq!(result, Err(Ok(Error::UnauthorizedEscrow)));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Issue #129: Distributor Fee Calculation Dry-Run Getter
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_calculate_distribution_splits_matches_actual_distribution() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ctx = setup(&env, 500, true); // 5% fee
+    create_and_fund(&ctx, 1_000, 50_000);
+    ctx.payment_asset.mint(&ctx.payer, &1_000);
+
+    let preview = ctx.distributor.calculate_distribution_splits(
+        &ctx.escrow_id,
+        &ctx.invoice_id,
+        &soroban_sdk::vec![
+            &env,
+            ctx.payment_token.address.clone(),
+            ctx.seller.clone(),
+            ctx.buyer.clone(),
+            ctx.admin.clone()
+        ],
+        &soroban_sdk::vec![&env, 1_000i128, 1_000i128, 950i128, 500i128],
+    );
+
+    assert_eq!(preview.seller_amount, 950);
+    assert_eq!(preview.investor_amount, 950);
+    assert_eq!(preview.platform_fee, 50);
+    assert_eq!(preview.total_distribution, 1_000);
+
+    // Dry-run must not mutate any state or move funds.
+    let state = ctx
+        .distributor
+        .get_distribution_state(&ctx.escrow_id, &ctx.invoice_id);
+    assert_eq!(state.paid_distributed, 0);
+    assert_eq!(ctx.payment_token.balance(&ctx.seller), 0);
+    assert_eq!(ctx.payment_token.balance(&ctx.buyer), 0);
+
+    // The real distribution then produces the same numbers the preview promised.
+    ctx.escrow
+        .record_payment(&ctx.invoice_id, &ctx.payer, &1_000);
+    assert_eq!(ctx.payment_token.balance(&ctx.seller), 950);
+    assert_eq!(ctx.payment_token.balance(&ctx.buyer), 950);
+    assert_eq!(ctx.payment_token.balance(&ctx.admin), 50);
+}
+
+#[test]
+fn test_calculate_distribution_splits_rejects_invalid_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, _distributor_id, distributor) = distributor_only(&env);
+    let escrow = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "PREVIEW_BAD_BPS");
+
+    let result = distributor.try_calculate_distribution_splits(
+        &escrow,
+        &invoice_id,
+        &soroban_sdk::vec![&env, seller.clone(), seller, funder, seller.clone()],
+        &soroban_sdk::vec![&env, 1_000i128, 0i128, 500i128, 10_001u32 as i128],
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidBps)));
+}
+
+#[test]
+fn test_calculate_distribution_splits_rejects_nothing_to_distribute() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, _distributor_id, distributor) = distributor_only(&env);
+    let escrow = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "PREVIEW_NOTHING");
+
+    // paid_amount == already-distributed (0 == 0) -> nothing new to distribute.
+    let result = distributor.try_calculate_distribution_splits(
+        &escrow,
+        &invoice_id,
+        &soroban_sdk::vec![&env, seller.clone(), seller, funder, seller.clone()],
+        &soroban_sdk::vec![&env, 0i128, 0i128, 0i128, 0i128],
+    );
+
+    assert_eq!(result, Err(Ok(Error::NothingToDistribute)));
+}

--- a/contracts/payment-distributor/src/types.rs
+++ b/contracts/payment-distributor/src/types.rs
@@ -11,6 +11,8 @@ pub enum StorageKey {
     FeeRecipient,
     /// Re-entrancy guard flag for distribution entrypoints (Issue #127).
     Locked,
+    /// Whitelisted escrow contract address allowed to call distribute_payment (Issue #121).
+    EscrowContract,
 }
 
 #[contracttype]
@@ -85,4 +87,15 @@ pub struct AssetRoute {
     pub token: Address,
     pub amount: i128,
     pub split: DistributionSplit,
+}
+
+/// Dry-run preview of a `distribute_payment` split, with no state mutation or
+/// token transfers. Issue #129.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DistributionPreview {
+    pub seller_amount: i128,
+    pub investor_amount: i128,
+    pub platform_fee: i128,
+    pub total_distribution: i128,
 }


### PR DESCRIPTION
Closes #121, 
Closes #129 
Closes #131 

## Summary

- **#121** — Dynamic escrow contract address binding. Adds `StorageKey::EscrowContract` with admin-gated `set_escrow_contract` / `get_escrow_contract`, emitting an `escrow_contract_updated` event.
- **#131** — Whitelisted escrow origin enforcement. `distribute_payment` now rejects calls from an escrow address that doesn't match the bound one via the new `Error::UnauthorizedEscrow`. **Opt-in**: if no escrow has been bound, behavior is unchanged (backward compatible with existing deployments/tests).
- **#129** — Distributor fee calculation dry-run getter. New `calculate_distribution_splits` view returns a `DistributionPreview` (seller/investor/fee/total amounts) with no storage writes or token transfers. Shares its calculation core (`compute_split`) with `distribute_payment` so the preview and the real distribution can never drift.

## Tests

Added success + failure path unit tests in `test.rs` for all three: escrow binding (admin-only, event emission, requires-init), whitelist enforcement (open when unbound, accepts whitelisted, rejects mismatched), and the dry-run getter (matches actual distribution, rejects invalid BPS, rejects nothing-to-distribute).

`cargo build` and `cargo clippy` pass clean for `payment-distributor`. **Note:** `cargo test` currently cannot run repo-wide — `invoice-token` and `invoice-escrow` have pre-existing compile errors on `dev` (missing error/type variants referenced by their own `lib.rs`, plus a borrow-checker issue in `invoice-escrow`) that are unrelated to this PR and block the shared test binary that `payment-distributor`'s integration fixtures depend on. Verified this reproduces on a clean `upstream/dev` checkout with zero involvement from this diff — flagging separately rather than fixing inside this PR since it's a distinct, larger issue outside `payment-distributor` scope.

## Test plan

- [x] `cargo build` (payment-distributor) — clean
- [x] `cargo clippy` (payment-distributor) — clean, no warnings
- [x] `cargo fmt -- --check` — clean
- [ ] `cargo test` — blocked repo-wide by pre-existing unrelated invoice-token/invoice-escrow compile errors (see note above)