### PR TITLE
feat(escrow): implement milestone-based partial escrow funding (#80)

### DIFF
--- a/contracts/invoice-escrow/src/errors.rs
+++ b/contracts/invoice-escrow/src/errors.rs
@@ -43,11 +43,13 @@ pub enum Error {
     /// Asset decimals for payment token and invoice token do not align.
     InvalidAssetDecimals = 18,
     /// Nonce has already been consumed by a prior signed off-chain approval (replay attempt).
-    NonceAlreadyUsed = 18,
+    NonceAlreadyUsed = 19,
     /// Escrow is not yet in a terminal state (Settled, Refunded, or Cancelled) and cannot be cleaned up.
-    EscrowNotSettled = 19,
+    EscrowNotSettled = 20,
     /// Buyer is not whitelisted to fund escrows.
-    NotWhitelisted = 20,
+    NotWhitelisted = 21,
     /// Off-chain signature has expired (timestamp too old).
-    SignatureExpired = 21,
+    SignatureExpired = 22,
+    /// Funding amount does not meet the required milestone threshold.
+    InvalidMilestoneAmount = 23,
 }

--- a/contracts/invoice-escrow/src/events.rs
+++ b/contracts/invoice-escrow/src/events.rs
@@ -15,7 +15,6 @@ pub fn escrow_status_changed(env: &Env, inv_id: Symbol, status: EscrowStatus, ti
     );
 }
 
-/// Publish escrow_created event.
 pub fn escrow_created(
     env: &Env,
     inv_id: Symbol,
@@ -27,6 +26,7 @@ pub fn escrow_created(
     token: &Address,
     inv_token: &Address,
     commitment: &soroban_sdk::BytesN<32>,
+    funding_milestone: Option<i128>,
 ) {
     env.events().publish(
         (Symbol::new(env, "escrow_created"),),
@@ -40,6 +40,7 @@ pub fn escrow_created(
             token,
             inv_token,
             commitment,
+            funding_milestone,
         ),
     );
 }

--- a/contracts/invoice-escrow/src/integration_test.rs
+++ b/contracts/invoice-escrow/src/integration_test.rs
@@ -114,6 +114,7 @@ fn create_and_fund(ctx: &Ctx<'_>, amount: i128, due_date: u64) {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&ctx.env, "commitment"),
+        &None,
     );
     ctx.escrow.fund_escrow(&ctx.invoice_id, &ctx.buyer, &amount);
 }
@@ -319,6 +320,7 @@ fn test_integration_cancel_escrow_happy_path() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&env, "cancel_test"),
+        &None,
     );
     assert_eq!(
         ctx.escrow.get_escrow_status(&ctx.invoice_id),
@@ -360,6 +362,7 @@ fn test_integration_cancel_non_seller_rejected() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&env, "cancel_non_seller"),
+        &None,
     );
 
     let intruder = Address::generate(&env);
@@ -383,6 +386,7 @@ fn test_integration_fund_cancelled_escrow_rejected() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&env, "fund_cancelled"),
+        &None,
     );
     ctx.escrow.cancel_escrow(&ctx.invoice_id, &ctx.seller);
 
@@ -410,6 +414,7 @@ fn test_integration_pause_blocks_fund_and_payment() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&env, "pause_test"),
+        &None,
     );
 
     ctx.escrow.set_paused(&true);
@@ -553,6 +558,7 @@ fn test_integration_over_funding_rejected() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&env, "over_fund"),
+        &None,
     );
 
     // Purchase price is 1000; funding 1001 must fail.
@@ -614,6 +620,7 @@ fn test_integration_duplicate_invoice_id_rejected() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &commitment,
+        &None,
     );
 
     let result = ctx.escrow.try_create_escrow(
@@ -626,6 +633,7 @@ fn test_integration_duplicate_invoice_id_rejected() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &commitment,
+        &None,
     );
     assert_eq!(result, Err(Ok(errors::Error::EscrowExists)));
 }
@@ -652,6 +660,7 @@ fn test_integration_past_due_date_rejected() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&env, "past_due"),
+        &None,
     );
     assert_eq!(result, Err(Ok(errors::Error::InvalidDueDate)));
 }
@@ -672,6 +681,7 @@ fn test_integration_zero_due_date_rejected() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&env, "zero_due"),
+        &None,
     );
     assert_eq!(result, Err(Ok(errors::Error::InvalidDueDate)));
 }
@@ -704,6 +714,7 @@ fn test_integration_create_escrow_not_initialized() {
         &token,
         &inv_token,
         &test_commitment(&env, "no_init"),
+        &None,
     );
     assert_eq!(result, Err(Ok(errors::Error::NotInit)));
 }
@@ -729,6 +740,7 @@ fn test_integration_state_persistence_after_create() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &commitment,
+        &None,
     );
 
     let data = ctx.escrow.get_escrow(&ctx.invoice_id);
@@ -886,6 +898,7 @@ fn test_integration_two_independent_escrows() {
         &ctx_a.payment_token.address,
         &inv_token_b_id,
         &test_commitment(&env, "inv_b"),
+        &None,
     );
     ctx_a.escrow.fund_escrow(&inv_b_id, &buyer_b, &500);
 
@@ -934,6 +947,7 @@ fn test_integration_escrow_created_event_emitted() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &commitment,
+        &None,
     );
 
     let evts = env.events().all();
@@ -968,6 +982,7 @@ fn test_integration_escrow_cancelled_event_emitted() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&env, "cancel_event"),
+        &None,
     );
     ctx.escrow.cancel_escrow(&ctx.invoice_id, &ctx.seller);
 
@@ -1044,6 +1059,7 @@ fn test_integration_discounted_purchase_price() {
         &ctx.payment_token.address,
         &ctx.inv_token_id,
         &test_commitment(&env, "discount"),
+        &None,
     );
     ctx.escrow.fund_escrow(&ctx.invoice_id, &ctx.buyer, &900);
 

--- a/contracts/invoice-escrow/src/lib.rs
+++ b/contracts/invoice-escrow/src/lib.rs
@@ -102,6 +102,7 @@ impl InvoiceEscrow {
         payment_token: Address,
         invoice_token: Address,
         commitment: soroban_sdk::BytesN<32>,
+        funding_milestone: Option<i128>,
     ) -> Result<(), Error> {
         seller.require_auth();
         if face_value <= 0 || purchase_price <= 0 {
@@ -149,6 +150,7 @@ impl InvoiceEscrow {
             inv_token: invoice_token.clone(),
             paid_amt: 0,
             status: EscrowStatus::Created,
+            funding_milestone,
             commitment: commitment.clone(),
         };
         storage::set_escrow(&env, invoice_id.clone(), &data);
@@ -163,6 +165,7 @@ impl InvoiceEscrow {
             &payment_token,
             &invoice_token,
             &commitment,
+            data.funding_milestone,
         );
         events::escrow_status_changed(&env, invoice_id, EscrowStatus::Created, current_timestamp);
         Ok(())
@@ -271,6 +274,19 @@ impl InvoiceEscrow {
         let new_funded = data.funded_amt.checked_add(amount).ok_or(Error::Overflow)?;
         if new_funded > data.purchase_price {
             return Err(Error::InvalidAmount);
+        }
+
+        // Validate milestone constraints if a milestone is set
+        if let Some(milestone) = data.funding_milestone {
+            let remaining_to_fund = data.purchase_price.checked_sub(data.funded_amt).ok_or(Error::Overflow)?;
+            
+            // Funder is always allowed to just fund exactly the remaining amount to complete the escrow.
+            // If they are not completing the escrow, the amount must be at least the milestone and a multiple of it.
+            if amount != remaining_to_fund {
+                if amount < milestone || amount % milestone != 0 {
+                    return Err(Error::InvalidMilestoneAmount);
+                }
+            }
         }
 
         let token = token::Client::new(env, &data.token);

--- a/contracts/invoice-escrow/src/test.rs
+++ b/contracts/invoice-escrow/src/test.rs
@@ -113,6 +113,7 @@ impl MockTokenEnvironment {
             &env_self.payment_token.id,
             &env_self.inv_token_id,
             &test_commitment(&env, "multi_token_test"),
+        &None,
         );
 
         env_self
@@ -179,6 +180,7 @@ fn test_create_and_fund() {
         &payment_token.address,
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Fund escrow
@@ -287,6 +289,7 @@ fn test_two_token_escrow_different_tokens() {
         &token_a_id,
         &inv_token_id,
         &test_commitment(&env, "token_a_invoice"),
+        &None,
     );
 
     // Fund and settle with token A
@@ -340,6 +343,7 @@ fn test_two_token_escrow_separate_escrows() {
         &token_a_id,
         &inv_token_id,
         &test_commitment(&env, "token_a"),
+        &None,
     );
 
     let invoice_b = Symbol::new(&env, "INV_B");
@@ -353,6 +357,7 @@ fn test_two_token_escrow_separate_escrows() {
         &token_b_id,
         &inv_token_id,
         &test_commitment(&env, "token_b"),
+        &None,
     );
 
     // Fund and settle both independently
@@ -422,6 +427,7 @@ fn test_record_payment() {
         &payment_token.address,
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &amount);
@@ -480,6 +486,7 @@ fn test_escrow_created_event() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Assert escrow_created event was emitted
@@ -551,6 +558,7 @@ fn test_escrow_funded_event() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &amount);
@@ -606,6 +614,7 @@ fn test_payment_settled_event() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &amount);
@@ -663,6 +672,7 @@ fn test_escrow_refunded_event() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &amount);
@@ -721,6 +731,7 @@ fn test_no_settlement_event_on_invalid_state() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Try to record payment without funding first (should fail)
@@ -775,6 +786,7 @@ fn test_no_refund_event_on_invalid_state() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Set ledger timestamp past due date
@@ -847,6 +859,7 @@ fn test_create_escrow_requires_seller_auth() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     assert!(result.is_err());
 }
@@ -909,6 +922,7 @@ fn test_create_escrow_zero_amount() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
@@ -939,6 +953,7 @@ fn test_create_escrow_negative_amount() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
@@ -969,6 +984,7 @@ fn test_create_escrow_zero_face_value_only() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
@@ -999,6 +1015,7 @@ fn test_create_escrow_zero_purchase_price_only() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
@@ -1029,6 +1046,7 @@ fn test_create_escrow_negative_face_value_only() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
@@ -1059,6 +1077,7 @@ fn test_create_escrow_negative_purchase_price_only() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
@@ -1089,6 +1108,7 @@ fn test_zero_amount_does_not_create_escrow() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Verify the escrow was NOT created (status lookup should fail)
@@ -1129,6 +1149,7 @@ fn test_fund_escrow_zero_amount() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Zero amount funding should fail
@@ -1169,6 +1190,7 @@ fn test_create_escrow_duplicate_invoice_id() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Second create with same invoice_id should fail
@@ -1182,6 +1204,7 @@ fn test_create_escrow_duplicate_invoice_id() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::EscrowExists)));
 }
@@ -1275,6 +1298,7 @@ fn test_fund_escrow_already_funded() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // First funding should succeed
@@ -1312,6 +1336,7 @@ fn test_record_payment_not_funded() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Try to record payment without funding first
@@ -1353,6 +1378,7 @@ fn test_record_payment_already_settled() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &1000);
@@ -1397,6 +1423,7 @@ fn test_record_payment_amount_exceeds_escrow() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &1000);
@@ -1432,6 +1459,7 @@ fn test_refund_not_funded() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Set time past due date
@@ -1477,6 +1505,7 @@ fn test_refund_before_due_date() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &1000);
@@ -1523,6 +1552,7 @@ fn test_refund_at_due_date() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &1000);
@@ -1575,6 +1605,7 @@ fn test_refund_after_due_date() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &1000);
@@ -1628,6 +1659,7 @@ fn test_refund_already_settled() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &1000);
@@ -1679,6 +1711,7 @@ fn test_fee_calculation_zero_fee() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &1000);
@@ -1725,6 +1758,7 @@ fn test_fee_calculation_max_fee() {
         &payment_token_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &1000);
@@ -1840,6 +1874,7 @@ fn test_get_escrow_data() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     // Get escrow data and verify
@@ -1880,6 +1915,7 @@ fn test_create_escrow_not_initialized() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::NotInit)));
 }
@@ -1933,6 +1969,7 @@ fn test_partial_payment_lifecycle() {
         &payment_token.address,
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &amount);
@@ -2016,6 +2053,7 @@ fn test_refund_after_partial_payment() {
         &payment_token.address,
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
 
     escrow_client.fund_escrow(&invoice_id, &buyer, &amount);
@@ -2082,6 +2120,7 @@ fn test_record_payment_removes_initial_fund_even_on_full_payment() {
         &pt_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     escrow_client.fund_escrow(&invoice_id, &buyer, &amount);
 
@@ -2121,6 +2160,7 @@ fn setup_escrow_created(env: &Env) -> (Address, InvoiceEscrowClient<'_>, Address
         &pt_id.address(),
         &inv_token_id,
         &test_commitment(env, "test_invoice_data"),
+        &None,
     );
 
     let _ = (pt_asset,);
@@ -2199,6 +2239,7 @@ fn test_cancel_escrow_already_funded_rejected() {
         &pt_id.address(),
         &inv_token_id,
         &test_commitment(&env, "test_invoice_data"),
+        &None,
     );
     client.fund_escrow(&invoice_id, &buyer, &1000);
 
@@ -2291,6 +2332,7 @@ fn test_pause_blocks_lifecycle_operations_and_unpause_restores() {
         &pt_id.address(),
         &inv_token_id,
         &test_commitment(&env, "pause_test_invoice"),
+        &None,
     );
     assert_eq!(create_while_paused, Err(Ok(Error::Paused)));
 
@@ -2306,6 +2348,7 @@ fn test_pause_blocks_lifecycle_operations_and_unpause_restores() {
         &pt_id.address(),
         &inv_token_id,
         &test_commitment(&env, "pause_test_invoice"),
+        &None,
     );
 
     // Pause and verify fund_escrow is blocked
@@ -2364,6 +2407,7 @@ fn test_create_escrow_with_commitment() {
         &payment_token,
         &inv_token,
         &commitment,
+        &None,
     );
 
     // Verify escrow was created with commitment
@@ -2437,6 +2481,7 @@ fn test_commitment_included_in_created_event() {
         &payment_token,
         &inv_token,
         &commitment,
+        &None,
     );
 
     // Assert escrow_created event was emitted with commitment
@@ -2560,6 +2605,7 @@ fn test_commitment_persists_through_lifecycle() {
         &payment_token.address,
         &inv_token_id,
         &commitment,
+        &None,
     );
 
     // Verify commitment after creation
@@ -2615,6 +2661,7 @@ fn test_create_escrow_due_date_in_past_rejected() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "past_due_test"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::InvalidDueDate)));
 }
@@ -2649,6 +2696,7 @@ fn test_create_escrow_due_date_equal_to_current_timestamp_rejected() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "equal_timestamp_test"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::InvalidDueDate)));
 }
@@ -2679,6 +2727,7 @@ fn test_create_escrow_due_date_zero_rejected() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "zero_due_date_test"),
+        &None,
     );
     assert_eq!(result, Err(Ok(Error::InvalidDueDate)));
 }
@@ -2715,6 +2764,7 @@ fn test_create_escrow_due_date_in_future_accepted() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "future_due_test"),
+        &None,
     );
 
     // Verify escrow was created successfully
@@ -2757,6 +2807,7 @@ fn test_fund_escrow_signed_succeeds_with_valid_nonce() {
         &payment_token.address,
         &inv_token_id,
         &test_commitment(&env, "signed_fund_test"),
+        &None,
     );
 
     // A relayer submits the buyer's off-chain approved funding request with nonce 1.
@@ -2803,6 +2854,7 @@ fn test_fund_escrow_signed_rejects_replayed_nonce() {
         &payment_token.address,
         &inv_token_id,
         &test_commitment(&env, "signed_fund_replay_a"),
+        &None,
     );
     escrow_client.create_escrow(
         &invoice_id_b,
@@ -2814,6 +2866,7 @@ fn test_fund_escrow_signed_rejects_replayed_nonce() {
         &payment_token.address,
         &inv_token_id,
         &test_commitment(&env, "signed_fund_replay_b"),
+        &None,
     );
 
     escrow_client.fund_escrow_signed(&invoice_id_a, &buyer, &amount, &1u64);
@@ -2867,6 +2920,7 @@ fn test_cleanup_escrow_removes_settled_record() {
         &payment_token.address,
         &inv_token_id,
         &test_commitment(&env, "cleanup_test"),
+        &None,
     );
     escrow_client.fund_escrow(&invoice_id, &buyer, &amount);
     escrow_client.record_payment(&invoice_id, &payer, &amount);
@@ -2907,6 +2961,7 @@ fn test_cleanup_escrow_rejects_non_terminal_status() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "cleanup_non_terminal"),
+        &None,
     );
 
     let result = escrow_client.try_cleanup_escrow(&invoice_id, &seller);
@@ -2940,9 +2995,194 @@ fn test_cleanup_escrow_rejects_unauthorized_caller() {
         &payment_token,
         &inv_token,
         &test_commitment(&env, "cleanup_unauthorized"),
+        &None,
     );
     escrow_client.cancel_escrow(&invoice_id, &seller);
 
     let result = escrow_client.try_cleanup_escrow(&invoice_id, &stranger);
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+// ========== Milestone Funding Tests ==========
+
+#[test]
+fn test_fund_escrow_respects_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+
+    let admin = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let payment_token_admin = Address::generate(&env);
+    let pt_id = env.register_stellar_asset_contract_v2(payment_token_admin.clone());
+    let payment_token_asset = AssetClient::new(&env, &pt_id.address());
+    let inv_token_id = env.register_contract(None, MockInvoiceToken);
+
+    escrow_client.initialize(&admin, &300);
+
+    payment_token_asset.mint(&buyer, &1000);
+
+    let invoice_id = Symbol::new(&env, "INV_MILE");
+    let milestone = 200i128;
+    
+    escrow_client.create_escrow(
+        &invoice_id,
+        &seller,
+        &payer,
+        &1000,
+        &1000,
+        &1000000,
+        &pt_id.address(),
+        &inv_token_id,
+        &test_commitment(&env, "milestone_test"),
+        &Some(milestone),
+    );
+
+    // Fund exactly the milestone
+    escrow_client.fund_escrow(&invoice_id, &buyer, &milestone);
+    
+    // Fund a multiple of the milestone
+    escrow_client.fund_escrow(&invoice_id, &buyer, &(milestone * 2));
+    
+    let escrow = escrow_client.get_escrow(&invoice_id);
+    assert_eq!(escrow.funded_amt, milestone * 3);
+}
+
+#[test]
+fn test_fund_escrow_rejects_below_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+
+    let admin = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let payment_token_admin = Address::generate(&env);
+    let pt_id = env.register_stellar_asset_contract_v2(payment_token_admin.clone());
+    let payment_token_asset = AssetClient::new(&env, &pt_id.address());
+    let inv_token_id = env.register_contract(None, MockInvoiceToken);
+
+    escrow_client.initialize(&admin, &300);
+
+    payment_token_asset.mint(&buyer, &1000);
+
+    let invoice_id = Symbol::new(&env, "INV_BELOW");
+    let milestone = 200i128;
+    
+    escrow_client.create_escrow(
+        &invoice_id,
+        &seller,
+        &payer,
+        &1000,
+        &1000,
+        &1000000,
+        &pt_id.address(),
+        &inv_token_id,
+        &test_commitment(&env, "milestone_below_test"),
+        &Some(milestone),
+    );
+
+    // Fund below the milestone
+    let result = escrow_client.try_fund_escrow(&invoice_id, &buyer, &199);
+    assert_eq!(result, Err(Ok(Error::InvalidMilestoneAmount)));
+}
+
+#[test]
+fn test_fund_escrow_rejects_not_multiple_of_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+
+    let admin = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let payment_token_admin = Address::generate(&env);
+    let pt_id = env.register_stellar_asset_contract_v2(payment_token_admin.clone());
+    let payment_token_asset = AssetClient::new(&env, &pt_id.address());
+    let inv_token_id = env.register_contract(None, MockInvoiceToken);
+
+    escrow_client.initialize(&admin, &300);
+
+    payment_token_asset.mint(&buyer, &1000);
+
+    let invoice_id = Symbol::new(&env, "INV_MULT");
+    let milestone = 200i128;
+    
+    escrow_client.create_escrow(
+        &invoice_id,
+        &seller,
+        &payer,
+        &1000,
+        &1000,
+        &1000000,
+        &pt_id.address(),
+        &inv_token_id,
+        &test_commitment(&env, "milestone_mult_test"),
+        &Some(milestone),
+    );
+
+    // Fund above milestone but not a multiple
+    let result = escrow_client.try_fund_escrow(&invoice_id, &buyer, &250);
+    assert_eq!(result, Err(Ok(Error::InvalidMilestoneAmount)));
+}
+
+#[test]
+fn test_fund_escrow_allows_remainder_below_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+
+    let admin = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let payment_token_admin = Address::generate(&env);
+    let pt_id = env.register_stellar_asset_contract_v2(payment_token_admin.clone());
+    let payment_token_asset = AssetClient::new(&env, &pt_id.address());
+    let inv_token_id = env.register_contract(None, MockInvoiceToken);
+
+    escrow_client.initialize(&admin, &300);
+
+    payment_token_asset.mint(&buyer, &1000);
+
+    let invoice_id = Symbol::new(&env, "INV_REM");
+    let milestone = 300i128; // purchase_price is 1000, so remaining will be 100
+    
+    escrow_client.create_escrow(
+        &invoice_id,
+        &seller,
+        &payer,
+        &1000,
+        &1000,
+        &1000000,
+        &pt_id.address(),
+        &inv_token_id,
+        &test_commitment(&env, "milestone_rem_test"),
+        &Some(milestone),
+    );
+
+    escrow_client.fund_escrow(&invoice_id, &buyer, &900);
+    
+    // Remaining is 100, which is below milestone (300).
+    // Funder must provide exactly 100.
+    
+    let result_wrong = escrow_client.try_fund_escrow(&invoice_id, &buyer, &50);
+    assert_eq!(result_wrong, Err(Ok(Error::InvalidMilestoneAmount)));
+    
+    escrow_client.fund_escrow(&invoice_id, &buyer, &100);
+    
+    let escrow = escrow_client.get_escrow(&invoice_id);
+    assert_eq!(escrow.status, EscrowStatus::Funded);
 }

--- a/contracts/invoice-escrow/src/types.rs
+++ b/contracts/invoice-escrow/src/types.rs
@@ -82,6 +82,8 @@ pub struct EscrowData {
     pub paid_amt: i128,
     /// Current status.
     pub status: EscrowStatus,
+    /// Minimum chunk size required for each partial funding operation (except the final one).
+    pub funding_milestone: Option<i128>,
     /// Commitment hash: immutable on-chain anchor for off-chain invoice data (PDF hash, ERP ID, etc.).
     /// Set at creation, cannot be modified. SHA-256 hash (32 bytes).
     pub commitment: soroban_sdk::BytesN<32>,


### PR DESCRIPTION
## Description

This PR implements **Milestone-Based Partial Escrow Funding** for the `invoice-escrow` contract, fulfilling the requirements for Issue #80. 

By introducing a `funding_milestone` configuration during escrow creation, this PR prevents spam (dust attacks) and enforces predictable chunking of investor capital. Investors must now fund the escrow in discrete milestones or multiples thereof, except for the final transaction which can seamlessly clear the remaining unfunded balance.

### Fixes & Enhancements
- **Escrow Configuration**: Added an optional `funding_milestone: Option<i128>` field to `EscrowData` and updated the `create_escrow` function signature.
- **Boundary Validation**: Modified `fund_escrow_core` to enforce milestone constraints. Funding amounts must equal or be a multiple of the `funding_milestone`.
- **Exception for Exact Fills**: Added a vital exception allowing investors to fund exactly the `remaining_to_fund` amount, ensuring the escrow isn't left in a deadlocked state if the remainder is not a perfect multiple of the milestone.
- **Error Handling**: Added the `InvalidMilestoneAmount` error to strictly reject non-compliant amounts and corrected a numbering collision in previous enum variants.
- **Event Parity**: Updated the `escrow_created` event to log the milestone constraint.

## Changes Made
- `contracts/invoice-escrow/src/types.rs`: Updated `EscrowData` structure.
- `contracts/invoice-escrow/src/lib.rs`: Implemented core boundary validation logic in `fund_escrow_core` and modified `create_escrow`.
- `contracts/invoice-escrow/src/errors.rs`: Added `InvalidMilestoneAmount` (23) and incremented previously colliding error variants.
- `contracts/invoice-escrow/src/events.rs`: Included `funding_milestone` parameter in the `escrow_created` event payload.
- `contracts/invoice-escrow/src/test.rs` & `integration_test.rs`: Retrofitted existing tests with the new argument schema and appended comprehensive milestone boundary tests.

## Testing
- Tests skipped during push as requested, but the local suite has been thoroughly updated.
- New unit tests added to `test.rs`:
  - `test_fund_escrow_respects_milestone`
  - `test_fund_escrow_rejects_below_milestone`
  - `test_fund_escrow_rejects_not_multiple_of_milestone`
  - `test_fund_escrow_allows_remainder_below_milestone`

closes #80 
