### PR TITLE
security(escrow): enforce admin authorization in initialize (#177)

### DIFF
--- a/contracts/invoice-escrow/src/lib.rs
+++ b/contracts/invoice-escrow/src/lib.rs
@@ -37,6 +37,7 @@ fn ensure_not_paused(config: &Config) -> Result<(), Error> {
 impl InvoiceEscrow {
     /// Initialize the contract with admin and platform fee (basis points, e.g. 300 = 3%).
     pub fn initialize(env: Env, admin: Address, platform_fee_bps: u32) -> Result<(), Error> {
+        admin.require_auth();
         if storage::get_config(&env).is_some() {
             return Err(Error::AlreadyInit);
         }

--- a/contracts/invoice-escrow/src/test.rs
+++ b/contracts/invoice-escrow/src/test.rs
@@ -3186,3 +3186,17 @@ fn test_fund_escrow_allows_remainder_below_milestone() {
     let escrow = escrow_client.get_escrow(&invoice_id);
     assert_eq!(escrow.status, EscrowStatus::Funded);
 }
+
+#[test]
+#[should_panic(expected = "not authorized")]
+fn test_initialize_not_authorized() {
+    let env = Env::default();
+    // Do NOT mock_all_auths() here so that admin.require_auth() fails.
+    
+    let escrow_id = env.register(InvoiceEscrow, ());
+    let escrow_client = InvoiceEscrowClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+    
+    // This should panic because the test environment doesn't provide auth for `admin`
+    escrow_client.initialize(&admin, &300);
+}


### PR DESCRIPTION
## Description

This PR addresses the security vulnerability outlined in **Issue #177** by verifying and hardening authorization checks across all public methods in `contracts/invoice-escrow/src/lib.rs`.

During the audit, it was discovered that `initialize` lacked an `admin.require_auth()` check. Without this check, an attacker could potentially front-run contract initialization with arbitrary parameters, seizing administrative control of the deployed contract before the legitimate deployer could act.

### Fixes & Enhancements
- **Security Audit**: Audited all public entry points in `InvoiceEscrow`. 
  - Verified `seller.require_auth()` exists on `create_escrow` and `cancel_escrow`.
  - Verified `buyer.require_auth()` exists on `fund_escrow`.
  - Verified `payer.require_auth()` exists on `record_payment`.
  - Verified `caller.require_auth()` exists on `cleanup_escrow`.
  - Verified `admin.require_auth()` on `set_whitelist_enabled`, `set_buyer_whitelisted`, `update_platform_fee_bps`, `set_payment_distributor`, and `set_paused`.
- **Implementation**: Added `admin.require_auth()` to the `initialize` method to ensure the initialization parameters are explicitly authorized by the prospective administrator.
- **Testing**: Added `test_initialize_not_authorized` to strictly reproduce the unauthorized initialization vector and ensure the contract panics as expected when authorization is missing.

## Changes Made
- `contracts/invoice-escrow/src/lib.rs`: Added `admin.require_auth();` to the `initialize` method.
- `contracts/invoice-escrow/src/test.rs`: Appended `test_initialize_not_authorized` to reproduce the attack vector.

## Testing
- Tests bypassed during push per instructions, but unit tests were written to cover the edge case.
- `cargo clippy -- -D warnings` was validated.

closes #177 
